### PR TITLE
Configuration options enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+StatsConfig.cfg
+SymSettings.cfg
+project_name
+source/.DS_Store
+symbulation

--- a/source/SymOrg.h
+++ b/source/SymOrg.h
@@ -13,8 +13,8 @@ private:
 
 
 public:
-  // interaction value 0.5 default to start
-  Symbiont(double _intval=0.5, double _points = 0.0, std::set<int> _set = std::set<int>())
+  // neutral interaction value 0.0 default to start
+  Symbiont(double _intval=0.0, double _points = 0.0, std::set<int> _set = std::set<int>())
     : interaction_val(_intval), points(_points), res_types(_set) { ; }
   Symbiont(const Symbiont &) = default;
   Symbiont(Symbiont &&) = default;

--- a/source/SymOrg.h
+++ b/source/SymOrg.h
@@ -110,6 +110,85 @@ public:
   	}
   	
   }
+  
+  void DistribResources(int resources, double hostIntVal, double symIntVal) { // might want to declare a remainingResources variable just to make this easier to maintain
+	
+	double hostPortion = 0.0;
+	double hostDonation = 0.0;
+	double symPortion = 0.0;
+	double symReturn = 0.0;
+
+	
+	std::cout << "Dividing resources: " << resources << std::endl;
+	if (hostIntVal >= 0 && symIntVal >= 0)  {  
+	    hostDonation = resources * hostIntVal;
+	    hostPortion = resources - hostDonation;  
+	    
+	    std::cout << "Host keeps " << hostPortion << " and gives " << hostDonation << " to symbiont." << std::endl;
+	    
+	    symReturn = (hostDonation * symIntVal) * 5;
+	    symPortion = hostDonation - (hostDonation * symIntVal);
+	    
+	    std::cout << "Symbiont keeps " << symPortion << " and returns " << symReturn << " to host (with bonus)" << std::endl;
+
+	    hostPortion += symReturn;
+	    
+	    std::cout << "In the end, host gets " << hostPortion << std::endl;
+	    
+	    this->GiveSymPoints(symPortion);
+	    this->AddPoints(hostPortion);
+	    
+	} else if (hostIntVal <= 0 && symIntVal < 0) {
+	     double hostDefense = -1.0 * (hostIntVal * resources);
+	     std::cout << "Host invests " << hostDefense << " in defense (which is lost), ";
+	     resources = resources - hostDefense;
+	     std::cout << "leaving " << resources << " available for reproduction. " << std::endl;
+	     
+	     double symSteals = (hostIntVal - symIntVal) * resources;
+	     std::cout << "Symbiont steals " << symSteals << " resources." << std::endl;
+	     symPortion = symSteals;
+	     
+	     hostPortion = resources - symSteals;
+	     std::cout << "Leaving host receiving " << hostPortion << " resources." << std::endl;
+	     
+	    this->GiveSymPoints(symPortion);
+	    this->AddPoints(hostPortion);
+	     
+	
+	} else if (hostIntVal > 0 && symIntVal < 0) {
+		hostDonation = hostIntVal * resources;
+		hostPortion = resources - hostDonation;
+		std::cout << "Host donates " << hostDonation << " to symbiont." << std::endl;
+		resources = resources - hostDonation;
+		
+		double symSteals = -1.0 * (resources * symIntVal);
+		hostPortion = hostPortion - symSteals;
+		symPortion = hostDonation + symSteals;
+		std::cout << "Symbiont steals an additional " << symSteals << " resources, ";
+		std::cout << "leaving host with " << hostPortion << " resources.  ";
+		std::cout << "Symbiont has " << symPortion << " at end." << std::endl;
+		
+		this->GiveSymPoints(symPortion);
+	    this->AddPoints(hostPortion);
+		
+		
+	} else if (hostIntVal < 0 && symIntVal >= 0) {
+		double hostDefense = -1.0 * (hostIntVal * resources);
+		hostPortion = resources - hostDefense;
+		
+		std::cout << "Host invests " << hostDefense << " in defense against a friendly symbiont." << std::endl;
+		std::cout << "Host keeps " << hostPortion << " and symbiont gets nothing." << std::endl;
+		// symbiont gets nothing from antagonistic host
+		symPortion = 0.0;
+		
+		this->GiveSymPoints(symPortion);
+	    this->AddPoints(hostPortion);
+	} else {
+		std::cout << "Missed a logical case in distributing resources." << std::endl;
+	}
+
+}
+  
 
 };
 

--- a/source/SymOrg.h
+++ b/source/SymOrg.h
@@ -119,37 +119,37 @@ public:
 	double symReturn = 0.0;
 
 	
-	std::cout << "Dividing resources: " << resources << std::endl;
+//	std::cout << "Dividing resources: " << resources << std::endl;
 	if (hostIntVal >= 0 && symIntVal >= 0)  {  
 	    hostDonation = resources * hostIntVal;
 	    hostPortion = resources - hostDonation;  
 	    
-	    std::cout << "Host keeps " << hostPortion << " and gives " << hostDonation << " to symbiont." << std::endl;
+//	    std::cout << "Host keeps " << hostPortion << " and gives " << hostDonation << " to symbiont." << std::endl;
 	    
 	    symReturn = (hostDonation * symIntVal) * 5;
 	    symPortion = hostDonation - (hostDonation * symIntVal);
 	    
-	    std::cout << "Symbiont keeps " << symPortion << " and returns " << symReturn << " to host (with bonus)" << std::endl;
+//	    std::cout << "Symbiont keeps " << symPortion << " and returns " << symReturn << " to host (with bonus)" << std::endl;
 
 	    hostPortion += symReturn;
 	    
-	    std::cout << "In the end, host gets " << hostPortion << std::endl;
+//	    std::cout << "In the end, host gets " << hostPortion << std::endl;
 	    
 	    this->GiveSymPoints(symPortion);
 	    this->AddPoints(hostPortion);
 	    
 	} else if (hostIntVal <= 0 && symIntVal < 0) {
 	     double hostDefense = -1.0 * (hostIntVal * resources);
-	     std::cout << "Host invests " << hostDefense << " in defense (which is lost), ";
+//	     std::cout << "Host invests " << hostDefense << " in defense (which is lost), ";
 	     resources = resources - hostDefense;
-	     std::cout << "leaving " << resources << " available for reproduction. " << std::endl;
+//	     std::cout << "leaving " << resources << " available for reproduction. " << std::endl;
 	     
 	     double symSteals = (hostIntVal - symIntVal) * resources;
-	     std::cout << "Symbiont steals " << symSteals << " resources." << std::endl;
+//	     std::cout << "Symbiont steals " << symSteals << " resources." << std::endl;
 	     symPortion = symSteals;
 	     
 	     hostPortion = resources - symSteals;
-	     std::cout << "Leaving host receiving " << hostPortion << " resources." << std::endl;
+//	     std::cout << "Leaving host receiving " << hostPortion << " resources." << std::endl;
 	     
 	    this->GiveSymPoints(symPortion);
 	    this->AddPoints(hostPortion);
@@ -158,15 +158,15 @@ public:
 	} else if (hostIntVal > 0 && symIntVal < 0) {
 		hostDonation = hostIntVal * resources;
 		hostPortion = resources - hostDonation;
-		std::cout << "Host donates " << hostDonation << " to symbiont." << std::endl;
+//		std::cout << "Host donates " << hostDonation << " to symbiont." << std::endl;
 		resources = resources - hostDonation;
 		
 		double symSteals = -1.0 * (resources * symIntVal);
 		hostPortion = hostPortion - symSteals;
 		symPortion = hostDonation + symSteals;
-		std::cout << "Symbiont steals an additional " << symSteals << " resources, ";
-		std::cout << "leaving host with " << hostPortion << " resources.  ";
-		std::cout << "Symbiont has " << symPortion << " at end." << std::endl;
+//		std::cout << "Symbiont steals an additional " << symSteals << " resources, ";
+//		std::cout << "leaving host with " << hostPortion << " resources.  ";
+//		std::cout << "Symbiont has " << symPortion << " at end." << std::endl;
 		
 		this->GiveSymPoints(symPortion);
 	    this->AddPoints(hostPortion);
@@ -176,8 +176,8 @@ public:
 		double hostDefense = -1.0 * (hostIntVal * resources);
 		hostPortion = resources - hostDefense;
 		
-		std::cout << "Host invests " << hostDefense << " in defense against a friendly symbiont." << std::endl;
-		std::cout << "Host keeps " << hostPortion << " and symbiont gets nothing." << std::endl;
+//		std::cout << "Host invests " << hostDefense << " in defense against a friendly symbiont." << std::endl;
+//		std::cout << "Host keeps " << hostPortion << " and symbiont gets nothing." << std::endl;
 		// symbiont gets nothing from antagonistic host
 		symPortion = 0.0;
 		

--- a/source/SymWorld.h
+++ b/source/SymWorld.h
@@ -26,7 +26,7 @@ class SymWorld {
   double newIntVal(double _in = 0.5) {
         // get random deviation from original interaction values of host and symbiont
         // not sure how large the standard deviation value should be  
-  	 	double offset = random.GetRandNormal(0.0, 0.5);  // using sd (0.002) from dissertation
+  	 	double offset = random.GetRandNormal(0.0, 0.002);  // using sd (0.002) from dissertation
   	 	
   	 	double newVal = _in + offset;  
   	 	
@@ -46,7 +46,7 @@ class SymWorld {
   	   if (world.IsOccupied(i) == false) continue;  // no organism at that cell
   	   
   	  	double hostIntVal = world[i].GetIntVal();
-  	  	std::cout << std::endl << "Host interaction: " << hostIntVal << std::endl;
+ // 	  	std::cout << std::endl << "Host interaction: " << hostIntVal << std::endl;
   	  	double symIntVal = 0.0;
   	  	
   	  	if (world[i].HasSym()) {
@@ -55,11 +55,11 @@ class SymWorld {
   	    	symIntVal = 0.0;
   	    }
   	  	
-  	  	std::cout << "Symbiont interaction: " << symIntVal << std::endl;
+//  	  	std::cout << "Symbiont interaction: " << symIntVal << std::endl;
 		world[i].DistribResources(new_resources, hostIntVal, symIntVal); // --- NEW FUNCTION!!
 		
-		std::cout << "Host has: " << world[i].GetPoints() << " resources." << std::endl;
-		std::cout << "Symbiont has: " << world[i].GetSymbiont().GetPoints() << " resources." << std::endl;
+//		std::cout << "Host has: " << world[i].GetPoints() << " resources." << std::endl;
+//		std::cout << "Symbiont has: " << world[i].GetSymbiont().GetPoints() << " resources." << std::endl;
   	   
   	   }
 

--- a/source/SymWorld.h
+++ b/source/SymWorld.h
@@ -15,7 +15,7 @@ class SymWorld {
   	const int dimY = 10;
   	const int popSize = (dimX * dimY) / 2;  // number of organisms within the world
     world.ConfigPop(dimX,dimY);
-    world.Insert( Host(0.5, Symbiont(), std::set<int>(), 0.0), popSize);  
+    world.Insert( Host(0.0, Symbiont(), std::set<int>(), 0.0), popSize);  
     world.Print(PrintOrg);
   }
   
@@ -23,7 +23,7 @@ class SymWorld {
      world.Print(PrintOrg);
   }
   
-  double newIntVal(double _in = 0.5) {
+  double newIntVal(double _in = 0.0) {
         // get random deviation from original interaction values of host and symbiont
         // not sure how large the standard deviation value should be  
   	 	double offset = random.GetRandNormal(0.0, 0.002);  // using sd (0.002) from dissertation

--- a/source/SymWorld.h
+++ b/source/SymWorld.h
@@ -13,7 +13,7 @@ class SymWorld {
   SymWorld() {
   	const int dimX = 10;
   	const int dimY = 10;
-  	const int popSize = (dimX * dimY) / 2;  // number of organisms - anything less than full population results in segmentation fault at replication
+  	const int popSize = (dimX * dimY) / 2;  // number of organisms within the world
     world.ConfigPop(dimX,dimY);
     world.Insert( Host(0.5, Symbiont(), std::set<int>(), 0.0), popSize);  
     world.Print(PrintOrg);
@@ -26,70 +26,44 @@ class SymWorld {
   double newIntVal(double _in = 0.5) {
         // get random deviation from original interaction values of host and symbiont
         // not sure how large the standard deviation value should be  
-  	 	double offset = random.GetRandNormal(0.0, 0.002);  // using sd from dissertation
+  	 	double offset = random.GetRandNormal(0.0, 0.5);  // using sd (0.002) from dissertation
   	 	
   	 	double newVal = _in + offset;  
   	 	
-  	 	 if (newVal > 1 ) {
+  	 	 if (newVal > 1.0 ) {
   	 	      newVal = 1.0;
-  	 	   } else if (newVal < 0) {
-  	 	      newVal = 0.0;
+  	 	   } else if (newVal < -1.0) {
+  	 	      newVal = -1.0;
   	 	   }
   	 	   
   	 	 return newVal;
 
-}
+}	
   
   void Update(size_t new_resources=10) {
-  	 // divvy up and distribute resources to host and symbiont in each cell --- NEW FUNCTION!!
+  	 // divvy up and distribute resources to host and symbiont in each cell 
   	 for (size_t i = 0; i < world.GetSize(); i++) {
   	   if (world.IsOccupied(i) == false) continue;  // no organism at that cell
   	   
-  	   // initial disbursement to host and symbiont
-  	   size_t sym_portion = world[i].GetIntVal() * new_resources;
-//  	   std::cout << "Symbiont gets: " << sym_portion;
-  	   size_t host_portion = new_resources - sym_portion;
-//  	   std::cout << " and host keeps: " << host_portion << std::endl;
-  	   
-  	   world[i].AddPoints(host_portion);
-	   world[i].GiveSymPoints(sym_portion);
-  	   
-  	   // symbiont trades value back to host based on its interaction value
-  	   world[i].GetBackPoints(sym_portion);
+  	  	double hostIntVal = world[i].GetIntVal();
+  	  	std::cout << std::endl << "Host interaction: " << hostIntVal << std::endl;
+  	  	double symIntVal = 0.0;
+  	  	
+  	  	if (world[i].HasSym()) {
+  	    	symIntVal = world[i].GetSymbiont().GetIntVal();
+  	    } else {
+  	    	symIntVal = 0.0;
+  	    }
+  	  	
+  	  	std::cout << "Symbiont interaction: " << symIntVal << std::endl;
+		world[i].DistribResources(new_resources, hostIntVal, symIntVal); // --- NEW FUNCTION!!
+		
+		std::cout << "Host has: " << world[i].GetPoints() << " resources." << std::endl;
+		std::cout << "Symbiont has: " << world[i].GetSymbiont().GetPoints() << " resources." << std::endl;
   	   
   	   }
 
-  	 /* test print of resource values
-  	 std::cout << std::endl;
- 	 std::cout << "Resource values of hosts" << std::endl;
-  	 for (size_t i = 0; i < world.GetSize(); i++) {
-  	 	if (world.IsOccupied(i) == false) {
- 	 	    std::cout << " - "; // no resources to print
-  	 	}
-  	 	else {
-  	 	   double checkPoints;
-  	 	   checkPoints = world[i].GetPoints();
-  	 //		std::cout << " " << checkPoints << " ";
-  	    }
-  	   
-	}  
-	*/	
-	
-	/*test print of sym resource values
-	std::cout << std::endl;
-    std::cout << "Resource values of symbionts" << std::endl;
-  	 for (size_t i = 0; i < world.GetSize(); i++) {
-  	 	if (world.IsOccupied(i) == false) {
-  	 	   std::cout << " - "; // no resources to print
-  	 	}
-  	 	else {
-  	 	   double checkPoints;
-  	 	   checkPoints = world[i].GetSymbiont().GetPoints();
-        	std::cout << " " << checkPoints << " ";
-  	    }
-  	   
-	} 
-      std::cout << std::endl;  */
+ 
   	 
   	 // host reproduces if it can
   	 // assuming 100% vertical transmission rate right now

--- a/source/SymWorld.h
+++ b/source/SymWorld.h
@@ -8,14 +8,32 @@ class SymWorld {
  private:
   emp::Random random;
   emp::evo::GridWorld<Host> world;
+  
+  // declaring world configuration variables that will be initialized with the constructor
+  const int dimX;
+  const int dimY;
+  const int seedf;
+  const double muteRate; 
+  const double synergy;
+  const double vertTrans; 
+  
 
  public:
-  SymWorld() {
-  	const int dimX = 10;
-  	const int dimY = 10;
+  SymWorld(int gridx, int gridy, int randomSeed, double mutationProb, double bonus, double transProb)
+  :dimX(gridx), dimY(gridy), seedf(randomSeed), muteRate(mutationProb), synergy(bonus), vertTrans(transProb) {
+	// variables used only in the constructor
   	const int popSize = (dimX * dimY) / 2;  // number of organisms within the world
+
+  	random.ResetSeed(seedf);
     world.ConfigPop(dimX,dimY);
-    world.Insert( Host(0.0, Symbiont(), std::set<int>(), 0.0), popSize);  
+    world.Insert( Host(0.0, Symbiont(), std::set<int>(), 0.0), popSize);
+    // verify configuration
+    std::cout << "Checking configuration from within world constructor: " << std::endl;
+    std::cout << "X: " << dimX << " Y: " << dimY << std::endl;
+    std::cout << "Randomizer seed: " << seedf << std::endl;
+    std::cout << "Mutation rate: " << muteRate << std::endl;
+    std::cout << "Return bonus from symbionts: " << synergy << std::endl;
+    std::cout << "Vertical transmission rate: " << vertTrans << std::endl;  
     world.Print(PrintOrg);
   }
   
@@ -26,7 +44,7 @@ class SymWorld {
   double newIntVal(double _in = 0.0) {
         // get random deviation from original interaction values of host and symbiont
         // not sure how large the standard deviation value should be  
-  	 	double offset = random.GetRandNormal(0.0, 0.002);  // using sd (0.002) from dissertation
+  	 	double offset = random.GetRandNormal(0.0, muteRate); 
   	 	
   	 	double newVal = _in + offset;  
   	 	

--- a/source/native/symbulation.cc
+++ b/source/native/symbulation.cc
@@ -5,78 +5,7 @@
 using namespace std;
 
 
-void DistribResources(int resources) { // might want to declare a remainingResources variable just to make this easier to maintain
-	double hostIntVal = 0.0;
-	double symIntVal = 0.0;
-	
-	
-	double hostPortion = 0.0;
-	double hostDonation = 0.0;
-	double symPortion = 0.0;
-	double symReturn = 0.0;
-	
-	cout << "Host interaction value (between -1.0 and 1.0): " << endl;
-	cin >> hostIntVal;
-	cout << "Symbiont interaction value (between -1.0 and 1.0): " << endl;
-	cin >> symIntVal;
-	
-	cout << "Dividing resources: " << resources << endl;
-	if (hostIntVal >= 0 && symIntVal >= 0)  {  
-	    hostDonation = resources * hostIntVal;
-	    hostPortion = resources - hostDonation;  // I may have shorted the hosts in the first version
-	    
-	    cout << "Host keeps " << hostPortion << " and gives " << hostDonation << " to symbiont." << endl;
-	    
-	    symReturn = (hostDonation * symIntVal) * 5;
-	    symPortion = hostDonation - (hostDonation * symIntVal);
-	    
-	    cout << "Symbiont keeps " << symPortion << " and returns " << symReturn << " to host (with bonus)" << endl;
-	    
-	    hostPortion += symReturn;
-	    
-	    cout << "In the end, host has " << hostPortion << endl;
-	    
-	} else if (hostIntVal <= 0 && symIntVal < 0) {
-	     double hostDefense = -1.0 * (hostIntVal * resources);
-	     cout << "Host invests " << hostDefense << " in defense (which is lost), ";
-	     resources = resources - hostDefense;
-	     cout << "leaving " << resources << " available for reproduction. " << endl;
-	     
-	     double symSteals = (hostIntVal - symIntVal) * resources;
-	     cout << "Symbiont steals " << symSteals << " resources." << endl;
-	     symPortion = symSteals;
-	     
-	     hostPortion = resources - symSteals;
-	     cout << "Leaving host with " << hostPortion << " resources." << endl;
-	     
-	
-	} else if (hostIntVal > 0 && symIntVal < 0) {
-		hostDonation = hostIntVal * resources;
-		hostPortion = resources - hostDonation;
-		cout << "Host donates " << hostDonation << " to symbiont." << endl;
-		resources = resources - hostDonation;
-		
-		double symSteals = -1.0 * (resources * symIntVal);
-		hostPortion = hostPortion - symSteals;
-		symPortion = hostDonation + symSteals;
-		cout << "Symbiont steals an additional " << symSteals << " resources, ";
-		cout << "leaving host with " << hostPortion << " resources.  ";
-		cout << "Symbiont has " << symPortion << " at end." << endl;
-		
-		
-	} else if (hostIntVal < 0 && symIntVal >= 0) {
-		double hostDefense = -1.0 * (hostIntVal * resources);
-		hostPortion = resources - hostDefense;
-		
-		cout << "Host invests " << hostDefense << " in defense against a friendly symbiont." << endl;
-		cout << "Host keeps " << hostPortion << " and symbiont gets nothing." << endl;
-		// symbiont gets nothing from antagonistic host
-	} else {
-		cout << "Missed a logical case in distributing resources." << endl;
-	}
 
-}
-	
 
 int main()
 {
@@ -92,7 +21,6 @@ int main()
   cout << "1 - Set configurations." << endl;
   cout << "2 - Run updates for one (or more) generations." << endl;
   cout << "3 - Print the world." << endl;
-  cout << "4 - Test resource behavior cases. " << endl;
   cout << "5 - Print reports." << endl;
   cout << "9 - Quit." << endl;
   cin >> ControlOption;
@@ -100,15 +28,13 @@ int main()
   if (ControlOption == 1) {
   	cout << "Not ready for user configuration yet!" << endl;
   } else if (ControlOption == 2) {
-  	 cout << "How many generations? " << endl;
+  	 cout << "How many generations?? " << endl;
   	 cin >> updateRounds;
   	 for (int i = 0; i < updateRounds; i++) {
        world.Update(10);
        }
   } else if (ControlOption == 3) {
      world.PrintIt();
-  } else if (ControlOption == 4) {
-     DistribResources(20);
   } else if (ControlOption == 5) {
   	 cout << "Reports not ready yet." << endl;
   }

--- a/source/native/symbulation.cc
+++ b/source/native/symbulation.cc
@@ -28,7 +28,7 @@ int main()
   if (ControlOption == 1) {
   	cout << "Not ready for user configuration yet!" << endl;
   } else if (ControlOption == 2) {
-  	 cout << "How many generations? " << endl;
+  	 cout << "How many generations?? " << endl;
   	 cin >> updateRounds;
   	 for (int i = 0; i < updateRounds; i++) {
        world.Update(10);

--- a/source/native/symbulation.cc
+++ b/source/native/symbulation.cc
@@ -2,47 +2,179 @@
 
 #include <iostream>
 #include "../SymWorld.h"
+#include "config/ArgManager.h"
 using namespace std;
 
+EMP_BUILD_CONFIG( SymConfigBase,
+                 VALUE(SEED, double, 10, "What value should the random seed be?"),
+                 VALUE(MUTATION_RATE, double, 0.001, "Standard deviation of the distribution to mutate by"),
+                 VALUE(SYNERGY, double, 5, "Amount symbiont's returned resources should be multiplied by"),
+                 VALUE(VERTICAL_TRANSMISSION, double, 1, "Value 0 to 1 of probability of symbiont vertically transmitting when host reproduces"),
+                 VALUE(GRID_X, int, 100, "Width of the world"),
+                 VALUE(GRID_Y, int, 100, "Height of world"),
+                 VALUE(UPDATES, int, 1000, "Number of updates to run before quitting")
+                 )
 
 
-
-int main()
+int main(int argc, char * argv[])
 {
-
-  SymWorld world; 
-
+  
+    
+    SymConfigBase config;
+    
+    //config settings can be accessed by config.KEYWORD_NAME()
+    //ex: double seedf = config.SEED();
+    
+    // getting the default settings
+    double seedf = config.SEED();
+    double mutrate = config.MUTATION_RATE();
+    double symsyn = config.SYNERGY();
+    double vertrans = config.VERTICAL_TRANSMISSION();
+    double gridx = config.GRID_X();
+    double gridy = config.GRID_Y();
+    double numupdates = config.UPDATES();
+    
+  char ChangeSetting = 'N';
   int ControlOption = 0;
-  int updateRounds = 1;
+  int updateRounds = numupdates;
   
-  do {
-  cout << endl;
-  cout << "Options: " << endl;
-  cout << "1 - Set configurations." << endl;
-  cout << "2 - Run updates for one (or more) generations." << endl;
-  cout << "3 - Print the world." << endl;
-  cout << "5 - Print reports." << endl;
-  cout << "9 - Quit." << endl;
-  cin >> ControlOption;
   
-  if (ControlOption == 1) {
-  	cout << "Not ready for user configuration yet!" << endl;
-  } else if (ControlOption == 2) {
-  	 cout << "How many generations?? " << endl;
-  	 cin >> updateRounds;
-  	 for (int i = 0; i < updateRounds; i++) {
-       world.Update(10);
-       }
-  } else if (ControlOption == 3) {
-     world.PrintIt();
-  } else if (ControlOption == 5) {
-  	 cout << "Reports not ready yet." << endl;
-  }
-  else if (ControlOption == 9) {
-     continue;
-  } else {
-    cout << "Invalid choice!!" << endl;
-  }
-  
-   } while (ControlOption != 9) ;
-}
+    auto args = emp::cl::ArgManager(argc, argv);
+    
+    if (argc < 2) { // interactive mode
+            cout << endl << endl;
+            cout << "Initializing Symbulation!" << endl << endl;
+            cout << "Current settings are: " << endl;
+            cout << "Seed for randomizer: " << seedf << endl;
+            cout << "Mutation rate: " << mutrate << endl;
+            cout << "The multiplier for resource amount symbiont returns to host: " << symsyn << endl;
+            cout << "Vertical transmission probability (between 0 and 1): " << vertrans << endl;
+            cout << "Width of the world: " << gridx << endl;
+            cout << "Height of the world: " << gridy << endl << endl;
+            cout << "Do you want to change a setting? (Y/N) " << endl;
+            
+            cin >> ChangeSetting;
+            
+            if (ChangeSetting == 'y' || ChangeSetting == 'Y') {
+  	         	 do {
+  	         	 	cout << "Which option do you want to change?" << endl;
+  	         	 	cout << "1 - Seed for randomizer (" << seedf << ")"<< endl;
+          			cout << "2 - Mutation rate (" << mutrate << ")" << endl;
+           			cout << "3 - The multiplier for resource amount symbiont returns to host: " << symsyn << endl;
+         			cout << "4 - Vertical transmission probability (between 0 and 1): " << vertrans << endl;
+          			cout << "5 - Width of the world: " << gridx << endl;
+       			 	cout << "6 - Height of the world: " << gridy << endl;
+       			 	cout << "9 - Done changing settings." << endl << endl;
+            			
+            	   cin >> ControlOption;
+            	   
+            	   if (ControlOption == 1) {
+            	   		cout << "Enter new seed for randomizer: " << endl;
+            	   		cin >> seedf;
+            	   } else if (ControlOption == 2) {
+            	   		cout << "Enter mutation rate: " << endl;
+            	   		cin >> mutrate;
+            	   } else if (ControlOption == 3) {
+            	   		cout << "Enter returned resource multiplier: " << endl;
+            	   		cin >> symsyn;
+            	   } else if (ControlOption == 4) {
+            	   		cout << "Enter vertical transmission probability: " << endl;
+            	   		cin >> vertrans;
+            	   } else if (ControlOption == 5) {
+            	   		cout << "Enter new width size: " << endl;
+            	   		cin >> gridx;
+            	   } else if (ControlOption == 6) {
+            	   		cout << "Enter new height size: " << endl;
+            	   		cin >> gridy;
+            	   } else if (ControlOption == 9) {
+            	   		continue;
+            	   } else {
+            	   		cout << "Please enter a valid option." << endl;
+            	   }
+            	   
+	           	 } while (ControlOption != 9);
+            
+            }
+            
+            ControlOption = 0;
+            cout << "Creating World!!" << endl << endl;
+            SymWorld world(gridx, gridy, seedf, mutrate, symsyn, vertrans); 
+    
+    	do {  
+
+            cout << "Options: " << endl;
+            cout << "1 - Configure settings and create world." << endl;
+            cout << "2 - Run updates for one (or more) generations." << endl;
+            cout << "3 - Print the world." << endl;
+            cout << "5 - Print reports." << endl;
+            cout << "9 - Quit." << endl;
+            cin >> ControlOption;
+            
+            if (ControlOption == 1) {
+                cout << "Actually, I think this is too late to configure." << endl;
+                
+            } else if (ControlOption == 2) {
+                cout << "How many generations?? " << endl;
+                cin >> updateRounds;
+                for (int i = 0; i < updateRounds; i++) {
+                    world.Update(10);
+                }
+            } else if (ControlOption == 3) {
+                world.PrintIt();
+            } else if (ControlOption == 5) {
+                cout << "Reports not ready yet." << endl;
+            }
+            else if (ControlOption == 9) {
+                continue;
+            } else {
+                cout << "Invalid choice!!" << endl;
+            }
+            
+        } while (ControlOption != 9) ;
+    
+    } else if (argc > 1) {  // research mode
+        cout << "Research Mode Go!" << endl;
+        config.Read("SymSettings.cfg");
+        if (args.ProcessConfigOptions(config, std::cout, "SymSettings.cfg") == false) {
+         	cout << "There was a problem in processing the options file." << endl;
+         	exit(1);
+         }
+        if (args.TestUnknown() == false) {
+        	cout << "Issue with leftover arguments." << endl;
+        	exit(2); 
+        } // If there are leftover args, throw an error.
+        
+        // good to go
+        
+        // get updated settings from the file 
+		seedf = config.SEED();
+ 		mutrate = config.MUTATION_RATE();
+		symsyn = config.SYNERGY();
+		vertrans = config.VERTICAL_TRANSMISSION();
+		gridx = config.GRID_X();
+		gridy = config.GRID_Y();
+		numupdates = config.UPDATES();
+        
+            cout << endl << endl;
+            cout << "Initializing Symbulation!" << endl << endl;
+            cout << "Current settings are:" << endl;
+            cout << "Seed for randomizer: " << seedf << endl;
+            cout << "Mutation rate: " << mutrate << endl;
+            cout << "The multiplier for resource amount symbiont returns to host: " << symsyn << endl;
+            cout << "Vertical transmission probability (between 0 and 1): " << vertrans << endl;
+            cout << "Width of the world: " << gridx << endl;
+            cout << "Height of the world: " << gridy << endl << endl;
+        
+        cout << endl << "Initial world population:" << endl << endl;
+        SymWorld world(gridx, gridy, seedf, mutrate, symsyn, vertrans); 
+        
+        for (int i = 0; i < numupdates; i++) {
+            world.Update(10);
+            }
+        cout << endl << "World after " << numupdates << " generations." << endl << endl;
+        world.PrintIt();
+    } else {
+		cout << "Unexpected command line argument.  Exiting now."  << endl;
+    }
+    
+    }

--- a/source/native/symbulation.cc
+++ b/source/native/symbulation.cc
@@ -28,7 +28,7 @@ int main()
   if (ControlOption == 1) {
   	cout << "Not ready for user configuration yet!" << endl;
   } else if (ControlOption == 2) {
-  	 cout << "How many generations?? " << endl;
+  	 cout << "How many generations? " << endl;
   	 cin >> updateRounds;
   	 for (int i = 0; i < updateRounds; i++) {
        world.Update(10);


### PR DESCRIPTION
Can configure world via config file and command line.  Or, if you just start the program without command line arguments at all, you can set configuration options by the interface.  

At the moment command line options override config file options.  I need to tweak a bit so that you can specify that the user can opt to use the config file without any other options set on the command line.   Probably some sort of -MODE option.

Also, we still need to specify the number of resource points that are distributed between host and symbiont at each update.  