### PR TITLE
Lysogeny dev

### DIFF
--- a/source/Phage.test.cc
+++ b/source/Phage.test.cc
@@ -1,224 +1,224 @@
 #include "Phage.h"
 #include "Symbiont.h"
 
-// TEST_CASE("Phage constructor, GetIntVal") {
-//     emp::Ptr<emp::Random> random = new emp::Random(-1);
-//     SymWorld w(*random);
-//     SymConfigBase config;
-//     SymWorld * world = &w;
+TEST_CASE("Phage constructor, GetIntVal") {
+    emp::Ptr<emp::Random> random = new emp::Random(-1);
+    SymWorld w(*random);
+    SymConfigBase config;
+    SymWorld * world = &w;
     
-//     double int_val = -1;
-//     Phage * p = new Phage(random, world, &config, int_val);
-//     double expected_int_val = -1;
-//     REQUIRE(p->GetIntVal() == expected_int_val);
+    double int_val = -1;
+    Phage * p = new Phage(random, world, &config, int_val);
+    double expected_int_val = -1;
+    REQUIRE(p->GetIntVal() == expected_int_val);
 
-//     int_val = 0;
-//     Phage * p2 = new Phage(random, world, &config, int_val);
-//     expected_int_val = 0;
-//     REQUIRE(p2->GetIntVal() == expected_int_val);
-//     delete p;
-//     delete p2;
-// }
+    int_val = 0;
+    Phage * p2 = new Phage(random, world, &config, int_val);
+    expected_int_val = 0;
+    REQUIRE(p2->GetIntVal() == expected_int_val);
+    delete p;
+    delete p2;
+}
 
-// TEST_CASE("Phage reproduce") {
-//     emp::Ptr<emp::Random> random = new emp::Random(3);
-//     SymWorld w(*random);
-//     SymWorld * world = &w;
-//     SymConfigBase config;
-//     config.MUTATE_LYSIS_CHANCE(1);
-//     config.LYSIS_CHANCE(.5);
+TEST_CASE("Phage reproduce") {
+    emp::Ptr<emp::Random> random = new emp::Random(3);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    SymConfigBase config;
+    config.MUTATE_LYSIS_CHANCE(1);
+    config.LYSIS_CHANCE(.5);
 
-//     WHEN("Mutation rate is zero")  {
-//         double int_val = 0;
-//         double parent_orig_int_val = 0;
-//         double parent_orig_lysis_chance=.5;
-//         config.MUTATION_RATE(0);
-//         config.MUTATION_SIZE(0);
-//         emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         emp::Ptr<Organism> phage_baby = p->reproduce();
+    WHEN("Mutation rate is zero")  {
+        double int_val = 0;
+        double parent_orig_int_val = 0;
+        double parent_orig_lysis_chance=.5;
+        config.MUTATION_RATE(0);
+        config.MUTATION_SIZE(0);
+        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Organism> phage_baby = p->reproduce();
 
-//         THEN("Offspring's interaction value and lysis chance equals parent's interaction value and lysis chance") {
-//             int phage_baby_int_val = 0;
-//             REQUIRE( phage_baby->GetIntVal() == phage_baby_int_val);
-//             REQUIRE( phage_baby->GetIntVal() == parent_orig_int_val);
-//             REQUIRE( p->GetIntVal() == parent_orig_int_val);
+        THEN("Offspring's interaction value and lysis chance equals parent's interaction value and lysis chance") {
+            int phage_baby_int_val = 0;
+            REQUIRE( phage_baby->GetIntVal() == phage_baby_int_val);
+            REQUIRE( phage_baby->GetIntVal() == parent_orig_int_val);
+            REQUIRE( p->GetIntVal() == parent_orig_int_val);
 
-//             double phage_baby_lysis_chance = .5;
-//             REQUIRE( phage_baby->GetLysisChance() == phage_baby_lysis_chance);
-//             REQUIRE( phage_baby->GetLysisChance() == parent_orig_lysis_chance);
-//             REQUIRE( p->GetLysisChance() == parent_orig_lysis_chance);
-//         }
-//         THEN("Offspring's points and burst timer are zero") {
-//             int phage_baby_points = 0;
-//             int phage_baby_burst_timer = 0;
-//             REQUIRE( phage_baby->GetPoints() == phage_baby_points);
-//             REQUIRE(phage_baby->GetBurstTimer() == phage_baby_burst_timer);
-//         }
-//         delete p;
-//         delete phage_baby;
-//     }
-//     WHEN("Mutation rate is not zero") {
-//         double int_val = 0;
-//         double parent_orig_int_val = 0;
-//         double parent_orig_lysis_chance=.5;
-//         config.MUTATION_RATE(1);
-//         config.MUTATION_SIZE(0.002);
-//         emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         emp::Ptr<Organism> phage_baby = p->reproduce();
+            double phage_baby_lysis_chance = .5;
+            REQUIRE( phage_baby->GetLysisChance() == phage_baby_lysis_chance);
+            REQUIRE( phage_baby->GetLysisChance() == parent_orig_lysis_chance);
+            REQUIRE( p->GetLysisChance() == parent_orig_lysis_chance);
+        }
+        THEN("Offspring's points and burst timer are zero") {
+            int phage_baby_points = 0;
+            int phage_baby_burst_timer = 0;
+            REQUIRE( phage_baby->GetPoints() == phage_baby_points);
+            REQUIRE(phage_baby->GetBurstTimer() == phage_baby_burst_timer);
+        }
+        delete p;
+        delete phage_baby;
+    }
+    WHEN("Mutation rate is not zero") {
+        double int_val = 0;
+        double parent_orig_int_val = 0;
+        double parent_orig_lysis_chance=.5;
+        config.MUTATION_RATE(1);
+        config.MUTATION_SIZE(0.002);
+        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Organism> phage_baby = p->reproduce();
 
-//         THEN("Offspring's interaction value and lysis chance does not equal parent's interaction value and lysis chance") {
-//             double phage_baby_int_val = 0.0011560678;
-//             REQUIRE( phage_baby->GetIntVal() != parent_orig_int_val);
-//             REQUIRE( phage_baby->GetIntVal() == Approx(phage_baby_int_val));
+        THEN("Offspring's interaction value and lysis chance does not equal parent's interaction value and lysis chance") {
+            double phage_baby_int_val = 0.0011560678;
+            REQUIRE( phage_baby->GetIntVal() != parent_orig_int_val);
+            REQUIRE( phage_baby->GetIntVal() == Approx(phage_baby_int_val));
 
-//             double phage_baby_lysis_chance = 0.5027827107;
-//             REQUIRE( phage_baby->GetLysisChance() != parent_orig_lysis_chance);
-//             REQUIRE( phage_baby->GetLysisChance() == Approx(phage_baby_lysis_chance));
-//         }
+            double phage_baby_lysis_chance = 0.5027827107;
+            REQUIRE( phage_baby->GetLysisChance() != parent_orig_lysis_chance);
+            REQUIRE( phage_baby->GetLysisChance() == Approx(phage_baby_lysis_chance));
+        }
 
-//         THEN("Offspring's points and burst timer are zero") {
-//             int phage_baby_points = 0;
-//             REQUIRE( phage_baby->GetPoints() == phage_baby_points);
-//             int phage_baby_burst_timer = 0;
-//             REQUIRE( phage_baby->GetBurstTimer() == phage_baby_burst_timer);
-//         }
-//         delete p;
-//         delete phage_baby;
-//     }
-// }
+        THEN("Offspring's points and burst timer are zero") {
+            int phage_baby_points = 0;
+            REQUIRE( phage_baby->GetPoints() == phage_baby_points);
+            int phage_baby_burst_timer = 0;
+            REQUIRE( phage_baby->GetBurstTimer() == phage_baby_burst_timer);
+        }
+        delete p;
+        delete phage_baby;
+    }
+}
 
-// TEST_CASE("SetBurstTimer, IncBurstTimer")
-// {
-//     emp::Ptr<emp::Random> random = new emp::Random(5);
-//     SymWorld w(*random);
-//     SymWorld * world = &w;
-//     SymConfigBase config;
-//     double int_val = -1;
-//     emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+TEST_CASE("SetBurstTimer, IncBurstTimer")
+{
+    emp::Ptr<emp::Random> random = new emp::Random(5);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    SymConfigBase config;
+    double int_val = -1;
+    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
     
-//     // int default_burst_time = 0;
-//     REQUIRE(p->GetBurstTimer() == 0);
+    // int default_burst_time = 0;
+    REQUIRE(p->GetBurstTimer() == 0);
 
-//     p->IncBurstTimer();
-//     double incremented_burst_time = 2.0760424677;
-//     REQUIRE(p->GetBurstTimer() == Approx(incremented_burst_time));
+    p->IncBurstTimer();
+    double incremented_burst_time = 2.0760424677;
+    REQUIRE(p->GetBurstTimer() == Approx(incremented_burst_time));
 
-//     int burst_time = 15;
-//     p->SetBurstTimer(burst_time);
+    int burst_time = 15;
+    p->SetBurstTimer(burst_time);
     
-//     int expected_burst_time = 15;
-//     REQUIRE(p->GetBurstTimer() == expected_burst_time);
+    int expected_burst_time = 15;
+    REQUIRE(p->GetBurstTimer() == expected_burst_time);
 
-//     p->IncBurstTimer();
-//     incremented_burst_time = 17.2344552608;
-//     REQUIRE(p->GetBurstTimer() == Approx(incremented_burst_time));
+    p->IncBurstTimer();
+    incremented_burst_time = 17.2344552608;
+    REQUIRE(p->GetBurstTimer() == Approx(incremented_burst_time));
 
-// }
+}
 
-// TEST_CASE("Phage SetLysisChance, GetLysisChance"){
-//     emp::Ptr<emp::Random> random = new emp::Random(5);
-//     SymWorld w(*random);
-//     SymWorld * world = &w;
-//     SymConfigBase config;
-//     double int_val = -1;
-//     emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+TEST_CASE("Phage SetLysisChance, GetLysisChance"){
+    emp::Ptr<emp::Random> random = new emp::Random(5);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    SymConfigBase config;
+    double int_val = -1;
+    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
 
-//     double lysis_chance = 0.5;
-//     p->SetLysisChance(lysis_chance);
-//     double expected_lysis_chance = 0.5;
-//     REQUIRE(p->GetLysisChance() == expected_lysis_chance);
+    double lysis_chance = 0.5;
+    p->SetLysisChance(lysis_chance);
+    double expected_lysis_chance = 0.5;
+    REQUIRE(p->GetLysisChance() == expected_lysis_chance);
 
-//     delete p;
-// }
+    delete p;
+}
 
-// TEST_CASE("Phage uponInjection"){
-//     emp::Ptr<emp::Random> random = new emp::Random(5);
-//     SymWorld w(*random);
-//     SymWorld * world = &w;
-//     SymConfigBase config;
-//     double int_val = -1;
-//     config.LYSIS_CHANCE(1);
-//     emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);  
+TEST_CASE("Phage uponInjection"){
+    emp::Ptr<emp::Random> random = new emp::Random(5);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    SymConfigBase config;
+    double int_val = -1;
+    config.LYSIS_CHANCE(1);
+    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);  
 
-//     //initialization of phage sets lysogeny to false
-//     bool expected_lysogeny = false;
-//     REQUIRE(p->GetLysogeny() == expected_lysogeny);
+    //initialization of phage sets lysogeny to false
+    bool expected_lysogeny = false;
+    REQUIRE(p->GetLysogeny() == expected_lysogeny);
 
-//     //phage should choose lysis by default
-//     p->uponInjection();
-//     expected_lysogeny = false;
-//     REQUIRE(p->GetLysogeny() == expected_lysogeny);
+    //phage should choose lysis by default
+    p->uponInjection();
+    expected_lysogeny = false;
+    REQUIRE(p->GetLysogeny() == expected_lysogeny);
 
-//     //if chance of lysis is 0, phage should choose lysogeny
-//     p->SetLysisChance(0.0);
-//     p->uponInjection();
-//     expected_lysogeny = true;
-//     REQUIRE(p->GetLysogeny() == expected_lysogeny);
+    //if chance of lysis is 0, phage should choose lysogeny
+    p->SetLysisChance(0.0);
+    p->uponInjection();
+    expected_lysogeny = true;
+    REQUIRE(p->GetLysogeny() == expected_lysogeny);
 
-//     delete p;
-// }
+    delete p;
+}
 
-// TEST_CASE("phage_mutate"){
-//     emp::Ptr<emp::Random> random = new emp::Random(5);
-//     SymWorld w(*random);
-//     SymWorld * world = &w;
-//     SymConfigBase config;
-//     config.LYSIS_CHANCE(.5);
+TEST_CASE("phage_mutate"){
+    emp::Ptr<emp::Random> random = new emp::Random(5);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    SymConfigBase config;
+    config.LYSIS_CHANCE(.5);
 
-//     WHEN("Mutation rate is not zero and chance of lysis mutations are enabled") {
-//         double int_val = 0;
-//         config.MUTATION_SIZE(0.002);
-//         config.MUTATE_LYSIS_CHANCE(1);
-//         emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         p->mutate();
-//         double lysis_chance_post_mutation = 0.503078154;
-//         THEN("Mutation occurs and chance of lysis changes") {
-//             REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-//         }
-//         delete p;
-//     }
+    WHEN("Mutation rate is not zero and chance of lysis mutations are enabled") {
+        double int_val = 0;
+        config.MUTATION_SIZE(0.002);
+        config.MUTATE_LYSIS_CHANCE(1);
+        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        p->mutate();
+        double lysis_chance_post_mutation = 0.503078154;
+        THEN("Mutation occurs and chance of lysis changes") {
+            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
+        }
+        delete p;
+    }
 
-//     WHEN("Mutation rate is not zero and chance of lysis mutations are not enabled"){
-//         double int_val = 0;
-//         config.MUTATION_SIZE(0.002);
-//         config.MUTATE_LYSIS_CHANCE(0);
-//         emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         p->mutate();
-//         double lysis_chance_post_mutation = 0.5;
-//         THEN("Mutation does not occur and chance of lysis does not change") {
-//             REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-//         }
-//         delete p;
-//     }
+    WHEN("Mutation rate is not zero and chance of lysis mutations are not enabled"){
+        double int_val = 0;
+        config.MUTATION_SIZE(0.002);
+        config.MUTATE_LYSIS_CHANCE(0);
+        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        p->mutate();
+        double lysis_chance_post_mutation = 0.5;
+        THEN("Mutation does not occur and chance of lysis does not change") {
+            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
+        }
+        delete p;
+    }
 
-//     WHEN("Mutation rate is zero and chance of lysis mutations are enabled"){
-//         double int_val = 0;
-//         config.MUTATION_RATE(0);
-//         config.MUTATION_SIZE(0);
-//         config.MUTATE_LYSIS_CHANCE(1);
-//         emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         p->mutate();
-//         double lysis_chance_post_mutation = 0.5;
-//         THEN("Mutation does not occur and chance of lysis does not change") {
-//             REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-//         }
-//         delete p;
-//     }
+    WHEN("Mutation rate is zero and chance of lysis mutations are enabled"){
+        double int_val = 0;
+        config.MUTATION_RATE(0);
+        config.MUTATION_SIZE(0);
+        config.MUTATE_LYSIS_CHANCE(1);
+        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        p->mutate();
+        double lysis_chance_post_mutation = 0.5;
+        THEN("Mutation does not occur and chance of lysis does not change") {
+            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
+        }
+        delete p;
+    }
 
-//     WHEN("Mutation rate is zero and chance of lysis mutations are not enabled"){
-//         double int_val = 0;
-//         config.MUTATION_RATE(0);
-//         config.MUTATION_SIZE(0);
-//         config.MUTATE_LYSIS_CHANCE(0);
-//         emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         p->mutate();
-//         double lysis_chance_post_mutation = 0.5;
-//         THEN("Mutation does not occur and chance of lysis does not change") {
-//             REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-//         }
-//         delete p;
-//     }
-// }
+    WHEN("Mutation rate is zero and chance of lysis mutations are not enabled"){
+        double int_val = 0;
+        config.MUTATION_RATE(0);
+        config.MUTATION_SIZE(0);
+        config.MUTATE_LYSIS_CHANCE(0);
+        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        p->mutate();
+        double lysis_chance_post_mutation = 0.5;
+        THEN("Mutation does not occur and chance of lysis does not change") {
+            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
+        }
+        delete p;
+    }
+}
 
 TEST_CASE("Phage process"){
     emp::Ptr<emp::Random> random = new emp::Random(9);
@@ -371,29 +371,29 @@ TEST_CASE("Phage process"){
     }
 }
 
-// TEST_CASE("Phage ProcessResources"){
-//     emp::Ptr<emp::Random> random = new emp::Random(9);
-//     SymWorld w(*random);
-//     SymWorld * world = &w;
-//     SymConfigBase config;
+TEST_CASE("Phage ProcessResources"){
+    emp::Ptr<emp::Random> random = new emp::Random(9);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    SymConfigBase config;
 
-//     WHEN("Phage is Lysogenic"){
-//         config.LYSIS(1);
-//         config.LYSIS_CHANCE(0);
+    WHEN("Phage is Lysogenic"){
+        config.LYSIS(1);
+        config.LYSIS_CHANCE(0);
 
-//         double int_val=0;
-//         //emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-//         emp::Ptr<Phage> p;
-//         p.New(random, world, &config, int_val);
-//         p->uponInjection();
+        double int_val=0;
+        //emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> p;
+        p.New(random, world, &config, int_val);
+        p->uponInjection();
 
-//         double sym_piece = 40;
-//         double expected_return = 40;
+        double sym_piece = 40;
+        double expected_return = 40;
 
-//         THEN("Phage doesn't take or give resources to the host"){
-//             REQUIRE(p->ProcessResources(sym_piece)==expected_return);
-//         }
+        THEN("Phage doesn't take or give resources to the host"){
+            REQUIRE(p->ProcessResources(sym_piece)==expected_return);
+        }
 
-//         p.Delete();
-//     }
-// }
+        p.Delete();
+    }
+}

--- a/stats_scripts/simple_repeat.py
+++ b/stats_scripts/simple_repeat.py
@@ -1,9 +1,9 @@
 #a script to run several replicates of several treatments locally
+import sys
 
 directory = "PartPop/"
-seeds = range(10, 21)
-start_mois = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 60, 80, 100]
-#start_mois = [1]
+#start_mois = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 60, 80, 100]
+start_mois = [1]
 slrs = [15]
 #verts = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 #sym_ints = [-1, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0]
@@ -22,16 +22,29 @@ def silent_cmd(command):
     R script calls unitl all neccesary data is created.'''
     return subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).wait()
 
-print("Copying SymSettings.cfg to "+directory)
+start_range = 10
+end_range = 21
+
+if(len(sys.argv) > 1):
+    start_range = int(sys.argv[1])
+    end_range = int(sys.argv[2])
+
+seeds = range(start_range, end_range)
+
+cmd("mkdir "+directory)
+print("Copying SymSettings.cfg and executable to "+directory)
 cmd("cp SymSettings.cfg "+directory)
+cmd("cp symbulation "+directory)
+cmd("cd "+directory)
+print("Using seeds", start_range, "up to", end_range)
 
 for a in seeds:
     for b in start_mois:
         for c in slrs:
             command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_SLR'+str(c)+' -SYM_LYSIS_RES '+str(c)
-#            command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_VT'+str(c)+' -VERTICAL_TRANSMISSION '+str(c)
-#            command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_SINT'+str(c)+' -SYM_INT '+str(c)
-#        command_str = './symbulation -SEED '+str(a)+' -VERTICAL_TRANSMISSION '+str(b)+' -FILE_NAME _VT'+str(b)+'_Seed'+str(a) + " -FILE_PATH "+directory
-            
+            # command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_VT'+str(c)+' -VERTICAL_TRANSMISSION '+str(c)
+            # command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_SINT'+str(c)+' -SYM_INT '+str(c)
+            # command_str = './symbulation -SEED '+str(a)+' -VERTICAL_TRANSMISSION '+str(b)+' -FILE_NAME _VT'+str(b)+'_Seed'+str(a) + " -FILE_PATH "+directory
+            settings_filename = directory+"Output_SM"+str(b)+"_Seed"+str(a)+"_SLR"+str(c)+".data"
             print(command_str)
-            cmd(command_str)
+            cmd(command_str+" > "+settings_filename)

--- a/stats_scripts/simple_repeat.py
+++ b/stats_scripts/simple_repeat.py
@@ -1,6 +1,6 @@
 #a script to run several replicates of several treatments locally
-#RUN SIMPLE_REPEATS.PY FROM WITHIN THE FOLDER WHERE THE DATA SHOULD GO
-#EX: INSIDE OF SymbulationEmp/Data, RUN python3 ../stats_scripts/simple_repeats.py
+#RUN SIMPLE_REPEAT.PY FROM WITHIN THE FOLDER WHERE THE DATA SHOULD GO
+#EX: INSIDE OF SymbulationEmp/Data, RUN python3 ../stats_scripts/simple_repeat.py
 import sys
 
 directory = "PartPop/"

--- a/stats_scripts/simple_repeat.py
+++ b/stats_scripts/simple_repeat.py
@@ -1,4 +1,6 @@
 #a script to run several replicates of several treatments locally
+#RUN SIMPLE_REPEATS.PY FROM WITHIN THE FOLDER WHERE THE DATA SHOULD GO
+#EX: INSIDE OF SymbulationEmp/Data, RUN python3 ../stats_scripts/simple_repeats.py
 import sys
 
 directory = "PartPop/"
@@ -31,20 +33,18 @@ if(len(sys.argv) > 1):
 
 seeds = range(start_range, end_range)
 
-cmd("mkdir "+directory)
 print("Copying SymSettings.cfg and executable to "+directory)
-cmd("cp SymSettings.cfg "+directory)
-cmd("cp symbulation "+directory)
-cmd("cd "+directory)
+cmd("cp ../SymSettings.cfg .")
+cmd("cp ../symbulation .")
 print("Using seeds", start_range, "up to", end_range)
 
 for a in seeds:
     for b in start_mois:
         for c in slrs:
-            command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_SLR'+str(c)+' -SYM_LYSIS_RES '+str(c)
+            command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_SLR'+str(c)+' -SYM_LYSIS_RES '+str(c)
             # command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_VT'+str(c)+' -VERTICAL_TRANSMISSION '+str(c)
             # command_str = './symbulation -SEED '+str(a)+' -START_MOI '+str(b)+' -FILE_PATH '+directory+' -FILE_NAME SM'+str(b)+'_Seed'+str(a)+'_SINT'+str(c)+' -SYM_INT '+str(c)
             # command_str = './symbulation -SEED '+str(a)+' -VERTICAL_TRANSMISSION '+str(b)+' -FILE_NAME _VT'+str(b)+'_Seed'+str(a) + " -FILE_PATH "+directory
-            settings_filename = directory+"Output_SM"+str(b)+"_Seed"+str(a)+"_SLR"+str(c)+".data"
+            settings_filename = "Output_SM"+str(b)+"_Seed"+str(a)+"_SLR"+str(c)+".data"
             print(command_str)
             cmd(command_str+" > "+settings_filename)


### PR DESCRIPTION
Changed simple_repeats.py so that it pipes output into files, run symbulation by using the copied version of SymSettings.cfg, and can take the seed range as command line arguments. Also forgot to uncomment some tests in Phage.tests.cc for last pull request, so I fixed that

Run simple_repeats.py as either of the following (command line arguments are optional):
stats_scripts/simple_repeats.py <START_RANGE> <END_RANGE>
stats_scripts/simple_repeats.py
