### PR TITLE
Fix compilation and add test so it doesn't break again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: "recursive"
 
       - name: run symbulation
-        run: cd SymbulationEmp && make debug && ./symbulation
+        run: cd SymbulationEmp && make debug && ./symbulation -GRID_X 5 -GRID_Y 5
 
       # Runs a single command using the runners shell
       - name: Make tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,9 @@ jobs:
           repository: devosoft/Empirical
           path: Empirical
           submodules: "recursive"
+	  
+      - name: run symbulation
+        run: cd SymbulationEmp && make debug && ./symbulation
 
       # Runs a single command using the runners shell
       - name: Make tests

--- a/source/SymWorld.h
+++ b/source/SymWorld.h
@@ -341,11 +341,11 @@ public:
               emp::vector<emp::Ptr<Organism>>& syms = pop[i]->GetSymbionts();
               bool all_lysogenic = true;
               for(long unsigned int j = 0; j < syms.size(); j++){
-                //if(syms[j]->IsPhage()){
+                if(syms[j]->IsPhage()){
                   if(syms[j]->GetLysogeny() == false){
                     all_lysogenic = false;
                   }
-                //}
+                }
               }
               if(all_lysogenic){
                 data_node_cfu->AddDatum(1);


### PR DESCRIPTION
Currently, running `make` in a fresh clone of Symbulation leads to an immediate seg-fault because `GetLysogeny` is called on a non-phage symbiont. This PR fixes the segfault by un-commenting out an if statement that checks whether the symbiont is a phage first, but this may or may not be a good solution (e.g. if it was commented out for a reason).

It also adds a step to the continuous integration tests that just runs symbulation with default parameters (except a smaller world, so it doesn't take forever), so that we'll know if this happens again.