### PR TITLE
correct EfficientSym Process name

### DIFF
--- a/source/EfficientSymbiont.h
+++ b/source/EfficientSymbiont.h
@@ -137,7 +137,7 @@ public:
    * Purpose: Mutating the efficiency of an efficient symbiont based upon the config setting 
    * for horizontal mutation size.
    */
-  void process(size_t location) {
+  void Process(size_t location) {
     if (h_trans) { //non-lytic horizontal transmission enabled
       if(GetPoints() >= sym_h_res) {
         // symbiont reproduces independently (horizontal transmission) if it has enough resources

--- a/source/EfficientSymbiont.test.cc
+++ b/source/EfficientSymbiont.test.cc
@@ -182,3 +182,38 @@ TEST_CASE("EfficientSymbiont HorizMutate") {
 
     }
 }
+
+TEST_CASE("EfficientSymbiont's Process called from Host") {
+    emp::Ptr<emp::Random> random = new emp::Random(10);
+    SymConfigBase config;
+    config.SYM_HORIZ_TRANS_RES(10);
+    config.EFFICIENT_SYM(1);
+    SymWorld w(*random);
+    SymWorld * world = &w;
+    w.Resize(2);
+    
+    config.MUTATION_SIZE(0);
+    config.MUTATION_RATE(0);
+
+    WHEN("An EfficientSymbiont is added to a Host and about to reproduce horizontally and Host's Process is called") {
+        double host_interaction_val = 1;
+        double host_points = 0;
+        Host * h = new Host(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
+        Host * h2 = new Host(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
+        double points = 11;
+        double int_val = 0;
+        double efficiency = 1;
+        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        h->AddSymbiont(s);
+        w.AddOrgAt(h, 0);
+        w.AddOrgAt(h2, 1);
+
+        h->Process(0);
+
+        THEN("EfficientSymbiont reproduces and offspring goes into neighboring Host") {
+            REQUIRE(h2->GetSymbionts()[0]->GetEfficiency() == efficiency);
+        }
+
+    }
+}
+


### PR DESCRIPTION
EfficientSym still had "process" instead of "Process" causing Symbiont's Process to be called instead. This wasn't caught because the two methods are the same except for the type of the offspring that is created, so probably would have been best avoided with a MakeNew function that handles the offspring creation