### PR TITLE
mutate() param and GetDoEcto earlier return

### DIFF
--- a/source/default_mode/Host.h
+++ b/source/default_mode/Host.h
@@ -1,6 +1,6 @@
 #ifndef HOST_H
 #define HOST_H
- 
+
 #include "../../../Empirical/include/emp/math/Random.hpp"
 #include "../../../Empirical/include/emp/tools/string_utils.hpp"
 #include <set>
@@ -390,7 +390,7 @@ public:
    *
    * Purpose: Increments age by one and kills it if too old.
    */
-  void growOlder(){
+  void GrowOlder(){
     age = age + 1;
     if(age > my_config->HOST_AGE_MAX() && my_config->HOST_AGE_MAX() > 0){
       SetDead();
@@ -533,7 +533,7 @@ public:
    * Purpose: To mutate a host's interaction value. This is called on newly generated
    * hosts to allow for evolution to occur.
    */
-  void mutate(){
+  void mutate(std::string mode = "vertical"){
     double mutation_size = my_config->HOST_MUTATION_SIZE();
     if (mutation_size == -1) mutation_size = my_config->MUTATION_SIZE();
     double mutation_rate = my_config->HOST_MUTATION_RATE();
@@ -608,9 +608,12 @@ public:
    */
   bool GetDoEctosymbiosis(size_t location){
     //a host is immune to ectosymbiosis if immunity is on and it has a sym.
-    bool is_immune = my_config->ECTOSYMBIOTIC_IMMUNITY() && HasSym();
-    bool valid_sym = my_world->GetSymAt(location) != nullptr && !my_world->GetSymAt(location)->GetDead();
-    return my_config->ECTOSYMBIOSIS() && (valid_sym == true) && (is_immune == false);
+    if (!my_config->ECTOSYMBIOSIS()) return false; //if the config setting is off, we immediately know that ectosymbiosis won't happen
+    else{
+      bool is_immune = my_config->ECTOSYMBIOTIC_IMMUNITY() && HasSym();
+      bool valid_sym = my_world->GetSymAt(location) != nullptr && !my_world->GetSymAt(location)->GetDead();
+      return (valid_sym == true) && (is_immune == false);
+    }
   }
 
   /**
@@ -687,7 +690,7 @@ public:
           }
         } //for each sym in syms
       } //if org has syms
-    growOlder();
+    GrowOlder();
   }
 };//Host
 #endif

--- a/source/default_mode/Symbiont.h
+++ b/source/default_mode/Symbiont.h
@@ -378,7 +378,7 @@ public:
    *
    * Purpose: Increments age by one and kills it if too old.
    */
-  void growOlder(){
+  void GrowOlder(){
     age = age + 1;
     if(age > my_config->SYM_AGE_MAX() && my_config->SYM_AGE_MAX() > 0){
       SetDead();
@@ -560,7 +560,7 @@ public:
         my_world->SymDoBirth(sym_baby, location);
       }
     }
-    growOlder();
+    GrowOlder();
     if (my_host.IsNull() && my_config->FREE_LIVING_SYMS() && !dead) {
       //if the symbiont should move, and hasn't been killed
       my_world->MoveFreeSym(location);

--- a/source/efficient_mode/EfficientSymbiont.h
+++ b/source/efficient_mode/EfficientSymbiont.h
@@ -91,7 +91,7 @@ public:
    * Purpose: Mutating the efficiency of an efficient symbiont based upon the config
    * setting for mutation size.
    */
-  void mutate(){
+  void mutate(std::string mode = "vertical"){
     Symbiont::mutate();
     if (random->GetDouble(0.0, 1.0) <= mut_rate) {
       efficiency += random->GetRandNormal(0.0, mut_size);

--- a/source/lysis_mode/Bacterium.h
+++ b/source/lysis_mode/Bacterium.h
@@ -121,7 +121,7 @@ public:
    * chosen from a normal distribution centered at 0, with a standard deviation that
    * is equal to the mutation size. Bacterium mutation can be turned on or off.
    */
-  void mutate() {
+  void mutate(std::string mode = "vertical") {
     Host::mutate();
 
     if(random->GetDouble(0.0, 1.0) <= my_config->MUTATION_RATE()){

--- a/source/lysis_mode/Phage.h
+++ b/source/lysis_mode/Phage.h
@@ -284,7 +284,7 @@ public:
    * deviation that is equal to the mutation size. Phage mutation can be
    * on or off.
    */
-  void mutate() {
+  void mutate(std::string mode = "vertical") {
    Symbiont::mutate();
     if (random->GetDouble(0.0, 1.0) <= mut_rate) {
       //mutate chance of lysis/lysogeny, if enabled

--- a/source/pgg_mode/Pggsym.h
+++ b/source/pgg_mode/Pggsym.h
@@ -102,7 +102,7 @@ public:
    *
    * Purpose:
    */
-  void mutate(){
+  void mutate(std::string mode = "vertical"){
     // double pre_value = interaction_val;
     Symbiont::mutate();
     if (random->GetDouble(0.0, 1.0) <= mut_rate) {

--- a/source/test/default_mode_test/Host.test.cc
+++ b/source/test/default_mode_test/Host.test.cc
@@ -424,7 +424,7 @@ TEST_CASE("GetDoEctosymbiosis"){
   }
 }
 
-TEST_CASE("Host growOlder"){
+TEST_CASE("Host GrowOlder"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     SymWorld w(*random);
     SymConfigBase config;

--- a/source/test/default_mode_test/Symbiont.test.cc
+++ b/source/test/default_mode_test/Symbiont.test.cc
@@ -539,7 +539,7 @@ TEST_CASE("Symbiont ProcessResources", "[default][efficient][lysis][pgg]"){
 
 }
 
-TEST_CASE("Symbiont growOlder"){
+TEST_CASE("Symbiont GrowOlder"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     SymWorld w(*random);
     w.Resize(2,2);

--- a/source/test/lysis_mode_test/Bacterium.test.cc
+++ b/source/test/lysis_mode_test/Bacterium.test.cc
@@ -50,7 +50,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(1);
         config.MUTATE_INC_VAL(1);
-        emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
+        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
         b->mutate();
 
         THEN("Then mutation occurs and the bacterium's host_inc_val mutates"){
@@ -66,7 +66,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(1);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
+        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
         b->mutate();
 
         THEN("Then mutations occur but do not occur in the host_inc_val"){
@@ -80,7 +80,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_RATE(0.0);
         config.MUTATION_SIZE(0.0);
         config.MUTATE_INC_VAL(1);
-        emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
+        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
         b->mutate();
 
         THEN("Mutations do not occur"){
@@ -94,7 +94,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_RATE(0.0);
         config.MUTATION_SIZE(0.0);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
+        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
         b->mutate();
 
         THEN("Mutations do not occur"){

--- a/source/test/lysis_mode_test/Phage.test.cc
+++ b/source/test/lysis_mode_test/Phage.test.cc
@@ -287,7 +287,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_INDUCTION_CHANCE(1);
         config.MUTATE_INC_VAL(1);
 
-        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
         p->mutate();
         THEN("Mutation occurs and chance of lysis changes") {
             REQUIRE(p->GetLysisChance() != 0.5);
@@ -309,7 +309,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_LYSIS_CHANCE(0);
         config.MUTATE_INDUCTION_CHANCE(0);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
         p->mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
@@ -329,7 +329,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_LYSIS_CHANCE(1);
         config.MUTATE_INDUCTION_CHANCE(1);
         config.MUTATE_INC_VAL(1);
-        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
         p->mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
@@ -349,7 +349,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_LYSIS_CHANCE(0);
         config.MUTATE_INDUCTION_CHANCE(0);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
         p->mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;

--- a/source/test/pgg_mode_test/Pggsym.test.cc
+++ b/source/test/pgg_mode_test/Pggsym.test.cc
@@ -34,7 +34,7 @@ TEST_CASE("Pggmutate", "[pgg]") {
         double int_val = 0;
         double donation =0.01;
         config.MUTATION_SIZE(0.002);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val,donation);
+        Organism * s = new PGGSymbiont(random, world, &config, int_val,donation);
 
         s->mutate();
 
@@ -52,7 +52,7 @@ TEST_CASE("Pggmutate", "[pgg]") {
         config.HORIZ_TRANS(true);
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val, points);
+        Organism * s = new PGGSymbiont(random, world, &config, int_val, points);
 
         s->mutate();
 


### PR DESCRIPTION
Added Organism mutate() parameter to subclass mutate() functions and modified GetDoEctosymbiosis() so that it returns false if the config option for ectosymbiosis is off, prior to determining if other factors are present.