### PR TITLE
Removing unnecessary instance variables 

### DIFF
--- a/source/default_mode/Symbiont.h
+++ b/source/default_mode/Symbiont.h
@@ -30,37 +30,6 @@ protected:
 
   /**
     *
-    * Purpose: Represents the points threshold for horizontal
-    * transmission to occur.
-    *
-  */
-  double sym_h_res = 100;
-
-  /**
-    *
-    * Purpose: Represents if horizontal transmission is allowed
-    * to occur.
-    *
-  */
-  bool h_trans = true;
-
-  /**
-    *
-    * Purpose: Represents the standard deviation of the values
-    * chosen as mutations of a symbiont's interaction value.
-    *
-  */
-  double mut_size = 0.002;
-
-  /**
-    *
-    * Purpose: Represents the probability (0-1) of mutation occurring.
-    *
-  */
-  double mut_rate = 0;
-
-  /**
-    *
     * Purpose: Represents if a symbiont is alive.
     * This is set to true when a symbiont is killed.
     *
@@ -74,14 +43,6 @@ protected:
     *
   */
   double infection_chance = 0.0;
-
-  /**
-    *
-    * Purpose: Represents the chance (between 0 and 1) that
-    * a free-living sym die trying to infect a host.
-    *
-  */
-  double infection_failure_rate = 0.0;
 
   /**
     *
@@ -124,15 +85,10 @@ public:
    * The constructor for symbiont
    */
   Symbiont(emp::Ptr<emp::Random> _random, emp::Ptr<SymWorld> _world, emp::Ptr<SymConfigBase> _config, double _intval=0.0, double _points = 0.0) :  interaction_val(_intval), points(_points), random(_random), my_world(_world), my_config(_config) {
-    sym_h_res = my_config->SYM_HORIZ_TRANS_RES();
-    h_trans = my_config->HORIZ_TRANS();
-    mut_rate = my_config->MUTATION_RATE();
-    infection_failure_rate = my_config->SYM_INFECTION_FAILURE_RATE();
     infection_chance = my_config->SYM_INFECTION_CHANCE();
     if (infection_chance == -2) infection_chance = random->GetDouble(0,1); //randomized starting infection chance
     if (infection_chance > 1 || infection_chance < 0) throw "Invalid infection chance. Must be between 0 and 1"; //exception for invalid infection chance
     
-    mut_size = my_config->MUTATION_SIZE();
     if ( _intval > 1 || _intval < -1) {
        throw "Invalid interaction value. Must be between -1 and 1";   // Exception for invalid interaction value
     };
@@ -379,8 +335,8 @@ public:
    * deviation.
    */
   void mutate(){
-    double local_rate = mut_rate;
-    double local_size = mut_size;
+    double local_rate = my_config->MUTATION_RATE();
+    double local_size = my_config->MUTATION_SIZE();
     
     if (random->GetDouble(0.0, 1.0) <= local_rate) {
       interaction_val += random->GetRandNormal(0.0, local_size);
@@ -461,7 +417,7 @@ public:
    */
   bool InfectionFails(){
     //note: this can be returned true, and an infecting sym can then be killed by a host that is already infected.
-    bool sym_dies = random->GetDouble(0.0, 1.0) < infection_failure_rate;
+    bool sym_dies = random->GetDouble(0.0, 1.0) < my_config->SYM_INFECTION_FAILURE_RATE();
     return sym_dies;
   }
 
@@ -562,8 +518,8 @@ public:
    * Purpose: To check and allow for horizontal transmission to occur
    */
   void HorizontalTransmission(size_t location) {
-    if (h_trans) { //non-lytic horizontal transmission enabled
-      if(GetPoints() >= sym_h_res) {
+    if (my_config->HORIZ_TRANS()) { //non-lytic horizontal transmission enabled
+      if(GetPoints() >= my_config->SYM_HORIZ_TRANS_RES()) {
         // symbiont reproduces independently (horizontal transmission) if it has enough resources
         //TODO: try just subtracting points to be consistent with vertical transmission
         //points = points - my_config->SYM_HORIZ_TRANS_RES();

--- a/source/efficient_mode/EfficientSymbiont.h
+++ b/source/efficient_mode/EfficientSymbiont.h
@@ -55,12 +55,12 @@ public:
     efficiency = _efficient;
     my_world = _world;
     if(my_config->HORIZ_MUTATION_RATE() < 0){
-      ht_mut_rate = mut_rate;
+      ht_mut_rate = my_config->MUTATION_RATE();
     } else {
       ht_mut_rate = my_config->HORIZ_MUTATION_RATE();
     }
     if(my_config->HORIZ_MUTATION_SIZE() < 0) {
-      ht_mut_size = mut_size;
+      ht_mut_size = my_config->MUTATION_SIZE();
     } else {
       ht_mut_size = my_config->HORIZ_MUTATION_SIZE();
     }
@@ -135,8 +135,8 @@ public:
     double local_size;
     double local_rate;
     if(mode == "vertical"){
-      local_rate = mut_rate;
-      local_size = mut_size;
+      local_rate = my_config->MUTATION_RATE();
+      local_size = my_config->MUTATION_SIZE();
     } else if(mode == "horizontal") {
       local_rate = ht_mut_rate;
       local_size = ht_mut_size;
@@ -212,8 +212,8 @@ public:
    * Purpose: To check and allow for horizontal transmission to occur
    */
   void HorizontalTransmission(size_t location) {
-    if (h_trans) { //non-lytic horizontal transmission enabled
-      if(GetPoints() >= sym_h_res) {
+    if (my_config->HORIZ_TRANS()) { //non-lytic horizontal transmission enabled
+      if(GetPoints() >= my_config->SYM_HORIZ_TRANS_RES()) {
         // symbiont reproduces independently (horizontal transmission) if it has enough resources
         // new symbiont in this host with mutated value
         SetPoints(0); //TODO: test just subtracting points instead of setting to 0

--- a/source/lysis_mode/Bacterium.h
+++ b/source/lysis_mode/Bacterium.h
@@ -21,15 +21,6 @@ protected:
 
   /**
     *
-    * Purpose: Represents whether the host's genome mutates or not. A boolean value. 0 for false, 1 for true.
-    * The host's genome gets compared against the phage's incorporation value.
-    *
-    *
-  */
-  bool mutate_host_inc_val = false;
-
-  /**
-    *
     * Purpose: Represents the world that the hosts are living in.
     *
   */
@@ -46,7 +37,6 @@ public:
   std::set<int> _set = std::set<int>(),
   double _points = 0.0) : Host(_random, _world, _config, _intval,_syms, _repro_syms, _set, _points)  {
     host_incorporation_val = my_config->HOST_INC_VAL();
-    mutate_host_inc_val = my_config->MUTATE_INC_VAL();
     if(host_incorporation_val == -1){
       host_incorporation_val = random->GetDouble(0.0, 1.0);
     }
@@ -127,7 +117,7 @@ public:
     if(random->GetDouble(0.0, 1.0) <= my_config->MUTATION_RATE()){
 
       //mutate host genome if enabled
-      if(mutate_host_inc_val){
+      if(my_config->MUTATE_INC_VAL()){
         host_incorporation_val += random->GetRandNormal(0.0, my_config->MUTATION_SIZE());
 
         if(host_incorporation_val < 0) host_incorporation_val = 0;

--- a/source/lysis_mode/Phage.h
+++ b/source/lysis_mode/Phage.h
@@ -15,13 +15,6 @@ protected:
 
   /**
     *
-    * Purpose: Represents if lysis is permitted.
-    *
-  */
-  bool lysis_enabled = true;
-
-  /**
-    *
     * Purpose: Represents if lysogeny is on.
     *
   */
@@ -36,46 +29,10 @@ protected:
 
   /**
     *
-    * Purpose: Represents whether the compatibility of the prophage to it's placement within the host's genome, mutates or not.
-    *
-  */
-  bool mutate_incorporation_val = false;
-
-  /**
-    *
-    * Purpose: Represents how long a lysis burst takes to occur.
-    *
-  */
-  double burst_time = 60;
-
-  /**
-    *
-    * Purpose: Represents resources required for symbiont to create offspring
-    *
-  */
-  double sym_lysis_res = 15;
-
-  /**
-    *
     * Purpose: Represents the chance of lysis
     *
   */
   double chance_of_lysis = 1;
-
-  /**
-    *
-    * Purpose: Represents if lysis mutation is permitted
-    *
-  */
-  bool mutate_chance_of_lysis = false;
-
-  /**
-    *
-    * Purpose: Represents if induction rate mutation is permitted
-    *
-  */
-  bool mutate_chance_of_induction = false;
-
 
   /**
     *
@@ -97,15 +54,9 @@ public:
    * The constructor for phage
    */
   Phage(emp::Ptr<emp::Random> _random, emp::Ptr<LysisWorld> _world, emp::Ptr<SymConfigBase> _config, double _intval=0.0, double _points = 0.0) : Symbiont(_random, _world, _config, _intval, _points) {
-    burst_time = my_config->BURST_TIME();
-    sym_lysis_res = my_config->SYM_LYSIS_RES();
-    lysis_enabled = my_config->LYSIS();
-    mutate_chance_of_induction = my_config->MUTATE_INDUCTION_CHANCE();
-    mutate_chance_of_lysis = my_config->MUTATE_LYSIS_CHANCE();
     chance_of_lysis = my_config->LYSIS_CHANCE();
     induction_chance = my_config->CHANCE_OF_INDUCTION();
     incorporation_val = my_config->PHAGE_INC_VAL();
-    mutate_incorporation_val = my_config->MUTATE_INC_VAL();
     if(chance_of_lysis == -1){
       chance_of_lysis = random->GetDouble(0.0, 1.0);
     }
@@ -286,21 +237,21 @@ public:
    */
   void mutate() {
     Symbiont::mutate();
-    double local_rate = mut_rate;
-    double local_size = mut_size;
+    double local_rate = my_config->MUTATION_RATE();
+    double local_size = my_config->MUTATION_SIZE();
     if (random->GetDouble(0.0, 1.0) <= local_rate) {
       //mutate chance of lysis/lysogeny, if enabled
-      if(mutate_chance_of_lysis){
+      if(my_config->MUTATE_LYSIS_CHANCE()){
         chance_of_lysis += random->GetRandNormal(0.0, local_size);
         if(chance_of_lysis < 0) chance_of_lysis = 0;
         else if (chance_of_lysis > 1) chance_of_lysis = 1;
       }
-      if(mutate_chance_of_induction){
+      if(my_config->MUTATE_INDUCTION_CHANCE()){
         induction_chance += random->GetRandNormal(0.0, local_size);
         if(induction_chance < 0) induction_chance = 0;
         else if (induction_chance > 1) induction_chance = 1;
       }
-      if(mutate_incorporation_val){
+      if(my_config->MUTATE_INC_VAL()){
         incorporation_val += random->GetRandNormal(0.0, local_size);
         if(incorporation_val < 0) incorporation_val = 0;
         else if (incorporation_val > 1) incorporation_val = 1;
@@ -370,15 +321,15 @@ public:
    */
   void LysisStep(){
     IncBurstTimer();
-    if(sym_lysis_res == 0) {
+    if(my_config->SYM_LYSIS_RES() == 0) {
       std::cout << "Lysis with a sym_lysis_res of 0 leads to an \
       infinite loop, please change" << std::endl;
       std::exit(1);
     }
-    while(GetPoints() >= sym_lysis_res) {
+    while(GetPoints() >= my_config->SYM_LYSIS_RES()) {
       emp::Ptr<Organism> sym_baby = reproduce();
       my_host->AddReproSym(sym_baby);
-      SetPoints(GetPoints() - sym_lysis_res);
+      SetPoints(GetPoints() - my_config->SYM_LYSIS_RES());
     }
   }
 
@@ -429,9 +380,9 @@ public:
    * Purpose: To process a phage, meaning check for reproduction, check for lysis, and move the phage.
    */
   void Process(size_t location) {
-    if(lysis_enabled && !GetHost().IsNull()) { //lysis enabled and phage is in a host
+    if(my_config->LYSIS() && !GetHost().IsNull()) { //lysis enabled and phage is in a host
       if(!lysogeny){ //phage has chosen lysis
-        if(GetBurstTimer() >= burst_time ) { //time to lyse!
+        if(GetBurstTimer() >= my_config->BURST_TIME() ) { //time to lyse!
           LysisBurst(location);
         }
         else { //not time to lyse

--- a/source/pgg_mode/Pggsym.h
+++ b/source/pgg_mode/Pggsym.h
@@ -104,8 +104,8 @@ public:
    */
   void mutate(){
     Symbiont::mutate();
-    if (random->GetDouble(0.0, 1.0) <= mut_rate) {
-      Pgg_donate += random->GetRandNormal(0.0, mut_size);
+    if (random->GetDouble(0.0, 1.0) <= my_config->MUTATION_RATE()) {
+      Pgg_donate += random->GetRandNormal(0.0, my_config->MUTATION_SIZE());
       if(Pgg_donate < 0) Pgg_donate = 0;
       else if (Pgg_donate > 1) Pgg_donate = 1;
     }

--- a/source/test/default_mode_test/Host.test.cc
+++ b/source/test/default_mode_test/Host.test.cc
@@ -220,56 +220,6 @@ TEST_CASE("DistributeResources", "[default]") {
     }
 }
 
-TEST_CASE("Phage Exclude", "[default]") {
-    emp::Ptr<emp::Random> random = new emp::Random(3);
-    SymWorld w(*random);
-
-    SymConfigBase config;
-    int sym_limit = 4;
-    config.SYM_LIMIT(sym_limit);
-
-    double int_val = 0;
-
-    WHEN("Phage exclude is set to false"){
-      bool phage_exclude = 0;
-      config.PHAGE_EXCLUDE(phage_exclude);
-      Host * h = new Host(random, &w, &config, int_val);
-
-      THEN("syms are added without issue"){
-        for(int i = 0; i < sym_limit; i++){
-          h->AddSymbiont(new Symbiont(random, &w, &config, int_val));
-        }
-        int num_syms = (h->GetSymbionts()).size();
-
-        REQUIRE(num_syms==sym_limit);
-        //with random seed 3 and phage exclusion on,
-        //num_syms not reach the sym_limit (would be 2 not 4)
-      }
-    }
-
-    WHEN("Phage exclude is set to true"){
-      bool phage_exclude = 1;
-      config.PHAGE_EXCLUDE(phage_exclude);
-
-      THEN("syms have a decreasing change of entering the host"){
-        int goal_num_syms[] = {3,3,3,3};
-
-        for(int i = 0; i < 4; i ++){
-          emp::Ptr<emp::Random> random = new emp::Random(i+1);
-          SymWorld w(*random);
-
-          Host * h = new Host(random, &w, &config, int_val);
-          for(double i = 0; i < 10; i++){
-            h->AddSymbiont(new Symbiont(random, &w, &config, int_val));
-          }
-          int host_num_syms = (h->GetSymbionts()).size();
-
-          REQUIRE(goal_num_syms[i] == host_num_syms);
-        }
-      }
-    }
-  }
-
   TEST_CASE("SetResInProcess, GetResInProcess") {
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     SymConfigBase config;

--- a/source/test/lysis_mode_test/Bacterium.test.cc
+++ b/source/test/lysis_mode_test/Bacterium.test.cc
@@ -189,3 +189,53 @@ TEST_CASE("Bacterium Process", "[lysis]"){
         }
     }
 }
+
+TEST_CASE("Phage Exclude", "[lysis]") {
+    emp::Ptr<emp::Random> random = new emp::Random(3);
+    SymWorld w(*random);
+
+    SymConfigBase config;
+    int sym_limit = 4;
+    config.SYM_LIMIT(sym_limit);
+
+    double int_val = 0;
+
+    WHEN("Phage exclude is set to false"){
+      bool phage_exclude = 0;
+      config.PHAGE_EXCLUDE(phage_exclude);
+      Host * h = new Host(random, &w, &config, int_val);
+
+      THEN("syms are added without issue"){
+        for(int i = 0; i < sym_limit; i++){
+          h->AddSymbiont(new Symbiont(random, &w, &config, int_val));
+        }
+        int num_syms = (h->GetSymbionts()).size();
+
+        REQUIRE(num_syms==sym_limit);
+        //with random seed 3 and phage exclusion on,
+        //num_syms not reach the sym_limit (would be 2 not 4)
+      }
+    }
+
+    WHEN("Phage exclude is set to true"){
+      bool phage_exclude = 1;
+      config.PHAGE_EXCLUDE(phage_exclude);
+
+      THEN("syms have a decreasing change of entering the host"){
+        int goal_num_syms[] = {3,3,3,3};
+
+        for(int i = 0; i < 4; i ++){
+          emp::Ptr<emp::Random> random = new emp::Random(i+1);
+          SymWorld w(*random);
+
+          Host * h = new Host(random, &w, &config, int_val);
+          for(double i = 0; i < 10; i++){
+            h->AddSymbiont(new Symbiont(random, &w, &config, int_val));
+          }
+          int host_num_syms = (h->GetSymbionts()).size();
+
+          REQUIRE(goal_num_syms[i] == host_num_syms);
+        }
+      }
+    }
+}


### PR DESCRIPTION
There were many instance variables of organisms that could have been easily accessed through the config object. Those instance variables were removed.