### PR TITLE
Test debugger, renaming, and worldsetup

### DIFF
--- a/source/Organism.h
+++ b/source/Organism.h
@@ -64,17 +64,17 @@ class Organism {
     std::cout << "SetAge called from Organism" << std::endl;
     throw "Organism method called!";
   }
-  virtual emp::Ptr<Organism> makeNew(){
-    std::cout << "makeNew called from Organism" << std::endl;
+  virtual emp::Ptr<Organism> MakeNew(){
+    std::cout << "MakeNew called from Organism" << std::endl;
     throw "Organism method called!";
   }
 
   //Symbiont functions
 
-  virtual void mutate() {
+  virtual void Mutate() {
     std::cout << "mutate called from Organism" << std::endl;
     throw "Organism method called!";}
-  virtual emp::Ptr<Organism> reproduce() {
+  virtual emp::Ptr<Organism> Reproduce() {
     std::cout << "reproduce called from Organism" << std::endl;
     throw "Organism method called!";}
   virtual void VerticalTransmission(emp::Ptr<Organism> host_baby) {
@@ -121,10 +121,10 @@ class Organism {
   virtual void SetEfficiency(double _in) {
     std::cout << "SetEfficiency called from Organism" << std::endl;
     throw "Organism method called!";}
-  virtual emp::Ptr<Organism> reproduce(std::string mode) {
+  virtual emp::Ptr<Organism> Reproduce(std::string mode) {
     std::cout << "EfficientSymbiont's reproduce called from Organism" << std::endl;
     throw "Organism method called!";}
-  virtual void mutate(std::string mode) {
+  virtual void Mutate(std::string mode) {
     std::cout << "EfficientSymbiont's mutate called from Organism" << std::endl;
     throw "Organism method called!";}
 
@@ -204,7 +204,7 @@ class Organism {
   virtual void SetInductionChance(double _in){
     std::cout << "SetInductionChance called from Organism" << std::endl;
     throw "Organism method called!";}
-  virtual void uponInjection() {
+  virtual void UponInjection() {
     std::cout << "chooseLysisOrLysogeny called from Organism" << std::endl;
     throw "Organism method called!";}
   virtual void LysisBurst(emp::WorldPosition location) {

--- a/source/default_mode/Host.h
+++ b/source/default_mode/Host.h
@@ -457,7 +457,7 @@ public:
     if((int)syms.size() < my_config->SYM_LIMIT() && SymAllowedIn()){
       syms.push_back(_in);
       _in->SetHost(this);
-      _in->uponInjection();
+      _in->UponInjection();
     } else {
       _in.Delete();
     }
@@ -516,7 +516,7 @@ public:
    *
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
-  emp::Ptr<Organism> makeNew(){
+  emp::Ptr<Organism> MakeNew(){
     emp::Ptr<Host> new_host = emp::NewPtr<Host>(random, my_world, my_config, GetIntVal());
     return new_host;
   }
@@ -528,9 +528,9 @@ public:
    *
    * Purpose: To create a new baby host and reset this host's points to 0.
    */
-  emp::Ptr<Organism> reproduce(){
-    emp::Ptr<Organism> host_baby = makeNew();
-    host_baby->mutate();
+  emp::Ptr<Organism> Reproduce(){
+    emp::Ptr<Organism> host_baby = MakeNew();
+    host_baby->Mutate();
     SetPoints(0);
     return host_baby;
   }
@@ -543,7 +543,7 @@ public:
    * Purpose: To mutate a host's interaction value. This is called on newly generated
    * hosts to allow for evolution to occur.
    */
-  void mutate(){
+  void Mutate(){
     double mutation_size = my_config->HOST_MUTATION_SIZE();
     if (mutation_size == -1) mutation_size = my_config->MUTATION_SIZE();
     double mutation_rate = my_config->HOST_MUTATION_RATE();
@@ -671,7 +671,7 @@ public:
     if (GetPoints() >= my_config->HOST_REPRO_RES() && repro_syms.size() == 0) {  // if host has more points than required for repro
         // will replicate & mutate a random offset from parent values
         // while resetting resource points for host and symbiont to zero
-       emp::Ptr<Organism> host_baby = reproduce();
+       emp::Ptr<Organism> host_baby = Reproduce();
 
         //Now check if symbionts get to vertically transmit
         for(size_t j = 0; j< (GetSymbionts()).size(); j++){

--- a/source/default_mode/SymWorld.h
+++ b/source/default_mode/SymWorld.h
@@ -87,6 +87,7 @@ protected:
   */
   fun_calc_info_t calc_info_fun;
 
+
   /**
     *
     * Purpose: Represents the systematics object tracking hosts.
@@ -137,7 +138,7 @@ public:
    *
    * Output: None
    *
-   * Purpose: To destruct the data nodes belonging to SymWorld to conserve memory.
+   * Purpose: To destruct the objects belonging to SymWorld to conserve memory.
    */
   ~SymWorld() {
     if (data_node_hostintval) data_node_hostintval.Delete();
@@ -152,6 +153,16 @@ public:
     if (data_node_freesymcount) data_node_freesymcount.Delete();
     if (data_node_hostedsymcount) data_node_hostedsymcount.Delete();
     if (data_node_uninf_hosts) data_node_uninf_hosts.Delete();
+
+    for(size_t i = 0; i < sym_pop.size(); i++){ //host population deletion is handled by empirical world destructor
+      if(sym_pop[i]) {
+        DoSymDeath(i);
+      }
+    }
+
+    if(track_phylogeny){ //host systematic deletion is handled by empirical world destructor
+      sym_sys.Delete();
+    }
   }
 
 
@@ -444,8 +455,11 @@ public:
     } else { //if it is not a host, then add it to the sym population
       //for symbionts, their place in their host's world is indicated by their ID
       size_t pos_id = pos.GetPopID();
-      if(!sym_pop[pos_id]) ++num_orgs;
-      else sym_pop[pos_id].Delete();
+      if(!sym_pop[pos_id]) {
+        ++num_orgs;
+      } else {
+        sym_pop[pos_id].Delete();
+      }
 
       //set the cell to point to the new sym
       sym_pop[pos_id] = new_org;
@@ -635,9 +649,9 @@ public:
    * Input: The size_t representing the location of the symbiont to be
    * extracted from the world.
    *
-   * Output: The pointer to the organism that was removed from the world
+   * Output: The pointer to the organism that was exgtracted from the world.
    *
-   * Purpose: To remove a symbiont from the world
+   * Purpose: To extract a symbiont from the world without deleting it.
    */
   emp::Ptr<Organism> ExtractSym(size_t i){
     emp::Ptr<Organism> sym;

--- a/source/default_mode/Symbiont.h
+++ b/source/default_mode/Symbiont.h
@@ -342,7 +342,7 @@ public:
    *
    * Purpose: Does nothing for now, added for backwards compatibility from phage to symbiont
    */
-  void uponInjection(){
+  void UponInjection(){
     //does nothing for now, added for backwards compatibility from phage to symbiont
   }
 
@@ -370,7 +370,7 @@ public:
    * from a normal distribution centered on 0 with the mutation size as the standard
    * deviation.
    */
-  void mutate(){
+  void Mutate(){
     double local_rate = my_config->MUTATION_RATE();
     double local_size = my_config->MUTATION_SIZE();
 
@@ -514,7 +514,7 @@ public:
    *
    * Purpose: To produce a new symbiont, identical to the original
    */
-  emp::Ptr<Organism> makeNew() {
+  emp::Ptr<Organism> MakeNew() {
     emp::Ptr<Symbiont> new_sym = emp::NewPtr<Symbiont>(random, my_world, my_config, GetIntVal());
     new_sym->SetInfectionChance(GetInfectionChance());
     return new_sym;
@@ -527,9 +527,9 @@ public:
    *
    * Purpose: To produce a new symbiont; does not remove resources from the parent, assumes that is handled by calling function
    */
-  emp::Ptr<Organism> reproduce() {
-    emp::Ptr<Organism> sym_baby = makeNew();
-    sym_baby->mutate();
+  emp::Ptr<Organism> Reproduce() {
+    emp::Ptr<Organism> sym_baby = MakeNew();
+    sym_baby->Mutate();
 
     if(my_config->PHYLOGENY() == 1){
       my_world->AddSymToSystematic(sym_baby, my_taxon);
@@ -547,7 +547,7 @@ public:
    */
   void VerticalTransmission(emp::Ptr<Organism> host_baby) {
     if((my_world->WillTransmit()) && GetPoints() >= my_config->SYM_VERT_TRANS_RES()){ //if the world permits vertical tranmission and the sym has enough resources, transmit!
-      emp::Ptr<Organism> sym_baby = reproduce();
+      emp::Ptr<Organism> sym_baby = Reproduce();
       points = points - my_config->SYM_VERT_TRANS_RES();
       host_baby->AddSymbiont(sym_baby);
     }
@@ -567,7 +567,7 @@ public:
         //TODO: try just subtracting points to be consistent with vertical transmission
         //points = points - my_config->SYM_HORIZ_TRANS_RES();
         SetPoints(0);
-        emp::Ptr<Organism> sym_baby = reproduce();
+        emp::Ptr<Organism> sym_baby = Reproduce();
         my_world->SymDoBirth(sym_baby, location);
       }
     }

--- a/source/default_mode/WorldSetup.cc
+++ b/source/default_mode/WorldSetup.cc
@@ -6,6 +6,16 @@
 #include "Host.h"
 #include "Symbiont.h"
 
+void setWorldConfigValues(emp::Ptr<SymWorld> world, emp::Ptr<SymConfigBase> my_config){
+  world->SetVertTrans(my_config->VERTICAL_TRANSMISSION());
+  world->SetTotalRes(my_config->LIMITED_RES_TOTAL());
+  world->SetFreeLivingSyms(my_config->FREE_LIVING_SYMS());
+  world->SetMoveFreeSyms(my_config->MOVE_FREE_SYMS());
+  world->SetTrackPhylogeny(my_config->PHYLOGENY());
+  world->SetNumPhyloBins(my_config->NUM_PHYLO_BINS());
+  world->SetResPerUpdate(my_config->RES_DISTRIBUTE());
+}
+
 void worldSetup(emp::Ptr<SymWorld> world, emp::Ptr<SymConfigBase> my_config) {
 // params
   emp::Random& random = world->GetRandom();
@@ -24,14 +34,10 @@ void worldSetup(emp::Ptr<SymWorld> world, emp::Ptr<SymConfigBase> my_config) {
 
   if (my_config->GRID() == 0) {world->SetPopStruct_Mixed(false);}
   else world->SetPopStruct_Grid(my_config->GRID_X(), my_config->GRID_Y(), false);
+
+  setWorldConfigValues(world, my_config);
 // settings
-  world->SetVertTrans(my_config->VERTICAL_TRANSMISSION());
-  world->SetTotalRes(my_config->LIMITED_RES_TOTAL());
-  world->SetFreeLivingSyms(my_config->FREE_LIVING_SYMS());
-  world->SetMoveFreeSyms(my_config->MOVE_FREE_SYMS());
-  world->SetTrackPhylogeny(my_config->PHYLOGENY());
-  world->SetNumPhyloBins(my_config->NUM_PHYLO_BINS());
-  world->SetResPerUpdate(my_config->RES_DISTRIBUTE());
+
   double comp_host_1 = 0;
   double comp_host_2 = 0.95;
 

--- a/source/efficient_mode/EfficientHost.h
+++ b/source/efficient_mode/EfficientHost.h
@@ -92,7 +92,7 @@ public:
    *
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
-  emp::Ptr<Organism> makeNew(){
+  emp::Ptr<Organism> MakeNew(){
     emp::Ptr<EfficientHost> host_baby = emp::NewPtr<EfficientHost>(random, my_world, my_config, GetIntVal());
     host_baby->SetEfficiency(GetEfficiency());
     return host_baby;

--- a/source/efficient_mode/EfficientSymbiont.h
+++ b/source/efficient_mode/EfficientSymbiont.h
@@ -137,7 +137,7 @@ public:
    * Purpose: Mutating the efficiency of an efficient symbiont based upon the config
    * setting for mutation size.
    */
-  void mutate(std::string mode){
+  void Mutate(std::string mode){
     double local_size;
     double local_rate;
     double int_rate;
@@ -192,7 +192,7 @@ public:
    *
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
-  emp::Ptr<Organism> makeNew(){
+  emp::Ptr<Organism> MakeNew(){
     emp::Ptr<EfficientSymbiont> sym_baby = emp::NewPtr<EfficientSymbiont>(random, my_world, my_config, GetIntVal());
     sym_baby->SetInfectionChance(GetInfectionChance());
     sym_baby->SetEfficiency(GetEfficiency());
@@ -206,9 +206,9 @@ public:
    *
    * Purpose: To produce a new symbiont
    */
-  emp::Ptr<Organism> reproduce(std::string mode) {
-    emp::Ptr<Organism> sym_baby = makeNew();
-    sym_baby->mutate(mode);
+  emp::Ptr<Organism> Reproduce(std::string mode) {
+    emp::Ptr<Organism> sym_baby = MakeNew();
+    sym_baby->Mutate(mode);
     return sym_baby;
   }
 
@@ -221,7 +221,7 @@ public:
    */
   void VerticalTransmission(emp::Ptr<Organism> host_baby) {
     if((my_world->WillTransmit()) && GetPoints() >= my_config->SYM_VERT_TRANS_RES()){ //if the world permits vertical tranmission and the sym has enough resources, transmit!
-      emp::Ptr<Organism> sym_baby = reproduce("vertical");
+      emp::Ptr<Organism> sym_baby = Reproduce("vertical");
       host_baby->AddSymbiont(sym_baby);
     }
   }
@@ -239,7 +239,7 @@ public:
         // symbiont reproduces independently (horizontal transmission) if it has enough resources
         // new symbiont in this host with mutated value
         SetPoints(0); //TODO: test just subtracting points instead of setting to 0
-        emp::Ptr<Organism> sym_baby = reproduce("horizontal");
+        emp::Ptr<Organism> sym_baby = Reproduce("horizontal");
         my_world->SymDoBirth(sym_baby, location);
       }
     }

--- a/source/efficient_mode/EfficientWorldSetup.cc
+++ b/source/efficient_mode/EfficientWorldSetup.cc
@@ -5,8 +5,9 @@
 #include "../ConfigSetup.h"
 #include "EfficientSymbiont.h"
 #include "EfficientHost.h"
+#include "../default_mode/WorldSetup.cc"
 
-void worldSetup(emp::Ptr<EfficientWorld> world, emp::Ptr<SymConfigBase> my_config) {
+void efficientWorldSetup(emp::Ptr<EfficientWorld> world, emp::Ptr<SymConfigBase> my_config) {
 // params
   emp::Random& random = world->GetRandom();
 
@@ -27,13 +28,7 @@ void worldSetup(emp::Ptr<EfficientWorld> world, emp::Ptr<SymConfigBase> my_confi
   if (my_config->GRID() == 0) {world->SetPopStruct_Mixed(false);}
   else world->SetPopStruct_Grid(my_config->GRID_X(), my_config->GRID_Y(), false);
 // settings
-  world->SetVertTrans(my_config->VERTICAL_TRANSMISSION());
-  world->SetTotalRes(my_config->LIMITED_RES_TOTAL());
-  world->SetFreeLivingSyms(my_config->FREE_LIVING_SYMS());
-  world->SetMoveFreeSyms(my_config->MOVE_FREE_SYMS());
-  world->SetTrackPhylogeny(my_config->PHYLOGENY());
-  world->SetNumPhyloBins(my_config->NUM_PHYLO_BINS());
-  world->SetResPerUpdate(my_config->RES_DISTRIBUTE());
+  setWorldConfigValues(world, my_config);
   double comp_host_1 = 0;
   double comp_host_2 = 0.95;
 

--- a/source/lysis_mode/Bacterium.h
+++ b/source/lysis_mode/Bacterium.h
@@ -98,7 +98,7 @@ public:
    *
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
-  emp::Ptr<Organism> makeNew(){
+  emp::Ptr<Organism> MakeNew(){
     emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, my_world, my_config, GetIntVal());
     host_baby->SetIncVal(GetIncVal());
     return host_baby;
@@ -113,8 +113,8 @@ public:
    * chosen from a normal distribution centered at 0, with a standard deviation that
    * is equal to the mutation size. Bacterium mutation can be turned on or off.
    */
-  void mutate() {
-    Host::mutate();
+  void Mutate() {
+    Host::Mutate();
 
     if(random->GetDouble(0.0, 1.0) <= my_config->MUTATION_RATE()){
 

--- a/source/lysis_mode/Phage.h
+++ b/source/lysis_mode/Phage.h
@@ -215,7 +215,7 @@ public:
    * If a phage chooses to be lysogenic, their interaction value will be 0 to represent
    * them being neutral.
    */
-  void uponInjection() {
+  void UponInjection() {
     double rand_chance = random->GetDouble(0.0, 1.0);
     if (rand_chance <= chance_of_lysis){
       lysogeny = false;
@@ -235,8 +235,8 @@ public:
    * deviation that is equal to the mutation size. Phage mutation can be
    * on or off.
    */
-  void mutate() {
-    Symbiont::mutate();
+  void Mutate() {
+    Symbiont::Mutate();
     double local_rate = my_config->MUTATION_RATE();
     double local_size = my_config->MUTATION_SIZE();
     if (random->GetDouble(0.0, 1.0) <= local_rate) {
@@ -266,7 +266,7 @@ public:
    *
    * Purpose: To produce a new symbiont, identical to the original
    */
-  emp::Ptr<Organism> makeNew() {
+  emp::Ptr<Organism> MakeNew() {
     emp::Ptr<Phage> sym_baby = emp::NewPtr<Phage>(random, my_world, my_config, GetIntVal());
     // pass down parent's genome
     sym_baby->SetIncVal(GetIncVal());
@@ -314,7 +314,7 @@ public:
       std::exit(1);
     }
     while(GetPoints() >= my_config->SYM_LYSIS_RES()) {
-      emp::Ptr<Organism> sym_baby = reproduce();
+      emp::Ptr<Organism> sym_baby = Reproduce();
       my_host->AddReproSym(sym_baby);
       SetPoints(GetPoints() - my_config->SYM_LYSIS_RES());
     }
@@ -332,7 +332,7 @@ public:
   void VerticalTransmission(emp::Ptr<Organism> host_baby){
     //lysogenic phage have 100% chance of vertical transmission, lytic phage have 0% chance
     if(lysogeny){
-      emp::Ptr<Organism> phage_baby = reproduce();
+      emp::Ptr<Organism> phage_baby = Reproduce();
       host_baby->AddSymbiont(phage_baby);
     }
   }

--- a/source/native/symbulation_efficient.cc
+++ b/source/native/symbulation_efficient.cc
@@ -48,7 +48,7 @@ int symbulation_main(int argc, char * argv[])
     world.SetUpFreeLivingSymFile(config.FILE_PATH()+"FreeLivingSyms_"+config.FILE_NAME()+file_ending).SetTimingRepeat(TIMING_REPEAT);
   }
 
-  worldSetup(&world, &config);
+  efficientWorldSetup(&world, &config);
   int numupdates = config.UPDATES();
 
   //Loop through updates

--- a/source/pgg_mode/PGGHost.h
+++ b/source/pgg_mode/PGGHost.h
@@ -135,7 +135,7 @@ public:
    *
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
-  emp::Ptr<Organism> makeNew(){
+  emp::Ptr<Organism> MakeNew(){
     emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, my_world, my_config, GetIntVal());
     return host_baby;
   }

--- a/source/pgg_mode/PGGSymbiont.h
+++ b/source/pgg_mode/PGGSymbiont.h
@@ -105,8 +105,8 @@ public:
    * value chosen from a normal distribution centered at 0, with a standard
    * deviation that is equal to the mutation size.
    */
-  void mutate(){
-    Symbiont::mutate();
+  void Mutate(){
+    Symbiont::Mutate();
     if (random->GetDouble(0.0, 1.0) <= my_config->MUTATION_RATE()) {
       PGG_donate += random->GetRandNormal(0.0, my_config->MUTATION_SIZE());
       if(PGG_donate < 0) PGG_donate = 0;
@@ -139,7 +139,7 @@ public:
    *
    * Purpose: To produce a new PGGSymbiont, identical to the original
    */
-  emp::Ptr<Organism> makeNew() {
+  emp::Ptr<Organism> MakeNew() {
     emp::Ptr<PGGSymbiont> sym_baby = emp::NewPtr<PGGSymbiont>(random, my_world, my_config, GetIntVal());
     sym_baby->SetInfectionChance(GetInfectionChance());
     sym_baby->SetDonation(GetDonation());

--- a/source/test/default_mode_test/DataNodes.test.cc
+++ b/source/test/default_mode_test/DataNodes.test.cc
@@ -17,7 +17,7 @@ TEST_CASE("GetHostCountDataNode", "[default]"){
     WHEN("a host is added"){
       size_t num_hosts = 4;
       for(size_t i = 0; i < num_hosts; i++){
-        w.AddOrgAt(new Host(&random, &w, &config, int_val), i);
+        w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), i);
       }
       w.Update();
       host_count_node = w.GetHostCountDataNode();
@@ -34,8 +34,9 @@ TEST_CASE("GetSymCountDataNode", "[default]"){
     emp::Random random(17);
     SymConfigBase config;
     int int_val = 0;
+    int world_size = 4;
     SymWorld w(random);
-    w.Resize(4);
+    w.Resize(world_size);
     w.SetFreeLivingSyms(1);
     config.SYM_LIMIT(2);
 
@@ -46,17 +47,17 @@ TEST_CASE("GetSymCountDataNode", "[default]"){
     WHEN("free and hosted syms are added"){
       size_t num_free_syms = 4;
       size_t num_hosted_syms = 2;
-      Host *h = new Host(&random, &w, &config, int_val);
-      w.AddOrgAt(h, 0);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+      w.AddOrgAt(host, 0);
       for(size_t i = 0; i < num_free_syms; i++){
-        w.AddOrgAt(new Symbiont(&random, &w, &config, int_val), emp::WorldPosition(0,i));
+        w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, int_val), emp::WorldPosition(0,i));
       }
       for(size_t i = 0; i < num_hosted_syms; i++){
-        h->AddSymbiont(new Symbiont(&random, &w, &config, int_val));
+        host->AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, int_val));
       }
 
       w.Update();
-      sym_count_node = w.GetSymCountDataNode();
+
       THEN("they are tracked by the data node"){
         REQUIRE(w.GetNumOrgs() == num_free_syms + 1); // and the host
         REQUIRE(sym_count_node.GetTotal() == num_free_syms + num_hosted_syms);
@@ -82,10 +83,10 @@ TEST_CASE("GetCountHostedSymsDataNode", "[default]"){
       size_t num_syms_per_host = 4;
       size_t num_hosts = 2;
       for(size_t i = 0; i < num_hosts; i++){
-        Host *h = new Host(&random, &w, &config, int_val);
-        w.AddOrgAt(h, i);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+        w.AddOrgAt(host, i);
         for(size_t j = 0; j < num_syms_per_host; j++){
-          h->AddSymbiont(new Symbiont(&random, &w, &config, int_val));
+          host->AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, int_val));
         }
       }
       w.Update();
@@ -95,7 +96,7 @@ TEST_CASE("GetCountHostedSymsDataNode", "[default]"){
       }
     }
     WHEN("a free sym is added"){
-      w.AddOrgAt(new Symbiont(&random, &w, &config, int_val), emp::WorldPosition(0,0));
+      w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, int_val), emp::WorldPosition(0,0));
       w.Update();
       THEN("the hosted sym data node doesn't track it"){
         REQUIRE(w.GetNumOrgs() == 1);
@@ -122,7 +123,7 @@ TEST_CASE("GetCountFreeSymsDataNode", "[default]"){
       size_t num_free_syms = 4;
 
       for(size_t i = 0; i < num_free_syms; i++){
-        w.AddOrgAt(new Symbiont(&random, &w, &config, int_val), emp::WorldPosition(0, i));
+        w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, int_val), emp::WorldPosition(0, i));
       }
 
       w.Update();
@@ -133,9 +134,9 @@ TEST_CASE("GetCountFreeSymsDataNode", "[default]"){
     }
 
     WHEN("a hosted sym is added"){
-      Host *h = new Host(&random, &w, &config, int_val);
-      w.AddOrgAt(h, 0);
-      h->AddSymbiont(new Symbiont(&random, &w, &config, int_val));
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+      w.AddOrgAt(host, 0);
+      host->AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, int_val));
       w.Update();
       THEN("it isn't tracked by the free sym data node"){
         REQUIRE(w.GetNumOrgs() == 1);
@@ -163,7 +164,7 @@ TEST_CASE("GetUninfectedHostsDataNode", "[default]"){
       size_t num_hosts = 10;
 
       for(size_t i = 0; i < num_hosts; i++){
-        w.AddOrgAt(new Host(&random, &w, &config, int_val), i);
+        w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), i);
       }
 
       w.Update();
@@ -175,7 +176,7 @@ TEST_CASE("GetUninfectedHostsDataNode", "[default]"){
       WHEN("some hosts are infected "){
         size_t num_infections = 2;
         for(size_t i = 0; i < num_infections; i++){
-          w.GetOrg(i).AddSymbiont(new Symbiont(&random, &w, &config, int_val));
+          w.GetOrg(i).AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, int_val));
         }
         w.Update();
         THEN("infected hosts are excluded from the uninfected host count"){
@@ -218,11 +219,11 @@ TEST_CASE("GetSymIntValDataNode", "[default]"){
       expected_hist_counts[17] = 2;
       expected_hist_counts[19] = 1;
 
-      Host *host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
       for(size_t i = 0; i < 3; i++){
-        w.AddOrgAt(new Symbiont(&random, &w, &config, free_sym_int_vals[i]), emp::WorldPosition(0,i));
-        host->AddSymbiont(new Symbiont(&random, &w, &config, hosted_sym_int_vals[i]));
+        w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, free_sym_int_vals[i]), emp::WorldPosition(0,i));
+        host->AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, hosted_sym_int_vals[i]));
       }
       w.Update();
 
@@ -270,11 +271,11 @@ TEST_CASE("GetFreeSymIntValDataNode", "[default]"){
       expected_hist_counts[5] = 1;
       expected_hist_counts[10] = 1;
 
-      Host *host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
       for(size_t i = 0; i < 3; i++){
-        w.AddOrgAt(new Symbiont(&random, &w, &config, free_sym_int_vals[i]), emp::WorldPosition(0,i));
-        host->AddSymbiont(new Symbiont(&random, &w, &config, hosted_sym_int_vals[i]));
+        w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, free_sym_int_vals[i]), emp::WorldPosition(0,i));
+        host->AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, hosted_sym_int_vals[i]));
       }
       w.Update();
 
@@ -319,11 +320,11 @@ TEST_CASE("GetHostedSymIntValDataNode", "[default]"){
       expected_hist_counts[17] = 2;
       expected_hist_counts[19] = 1;
 
-      Host *host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
       for(size_t i = 0; i < 3; i++){
-        w.AddOrgAt(new Symbiont(&random, &w, &config, free_sym_int_vals[i]), emp::WorldPosition(0,i));
-        host->AddSymbiont(new Symbiont(&random, &w, &config, hosted_sym_int_vals[i]));
+        w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, free_sym_int_vals[i]), emp::WorldPosition(0,i));
+        host->AddSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, hosted_sym_int_vals[i]));
       }
       w.Update();
 
@@ -368,7 +369,7 @@ TEST_CASE("GetHostIntValDataNode", "[default]"){
       expected_hist_counts[19] = 1;
 
       for(size_t i = 0; i < 4; i++){
-        w.AddOrgAt(new Host(&random, &w, &config, int_vals[i]), i);
+        w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_vals[i]), i);
       }
       w.Update();
 
@@ -416,12 +417,12 @@ TEST_CASE("GetSymInfectChanceDataNode", "[default]"){
       expected_hist_counts[7] = 1;
       expected_hist_counts[9] = 1;
 
-      Host *host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
 
       for(size_t i = 0; i < 3; i++){
-        Symbiont *sym1 = new Symbiont(&random, &w, &config, int_val);
-        Symbiont *sym2 = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
         sym1->SetInfectionChance(free_sym_infection_chances[i]);
         sym2->SetInfectionChance(hosted_sym_infection_chances[i]);
@@ -473,12 +474,12 @@ TEST_CASE("GetFreeSymInfectChanceDataNode", "[default]"){
       expected_hist_counts[2] = 1;
       expected_hist_counts[7] = 1;
 
-      Host *host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
 
       for(size_t i = 0; i < 3; i++){
-        Symbiont *sym1 = new Symbiont(&random, &w, &config, int_val);
-        Symbiont *sym2 = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
         sym1->SetInfectionChance(free_sym_infection_chances[i]);
         sym2->SetInfectionChance(hosted_sym_infection_chances[i]);
@@ -526,12 +527,12 @@ TEST_CASE("GetHostedSymInfectChanceDataNode", "[default]"){
       expected_hist_counts[3] = 2;
       expected_hist_counts[9] = 1;
 
-      Host *host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
 
       for(size_t i = 0; i < 3; i++){
-        Symbiont *sym1 = new Symbiont(&random, &w, &config, int_val);
-        Symbiont *sym2 = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
         sym1->SetInfectionChance(free_sym_infection_chances[i]);
         sym2->SetInfectionChance(hosted_sym_infection_chances[i]);

--- a/source/test/default_mode_test/Host.test.cc
+++ b/source/test/default_mode_test/Host.test.cc
@@ -162,7 +162,7 @@ TEST_CASE("Host Mutate", "[default]") {
         emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
 
         REQUIRE(host->GetIntVal() == int_val);
-        host->mutate();
+        host->Mutate();
         REQUIRE(host->GetIntVal() != int_val);
         REQUIRE(host->GetIntVal() <= 1);
         REQUIRE(host->GetIntVal() >= -1);
@@ -176,7 +176,7 @@ TEST_CASE("Host Mutate", "[default]") {
         config.MUTATION_RATE(0);
         emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
         REQUIRE(host->GetIntVal() == int_val);
-        host->mutate();
+        host->Mutate();
         REQUIRE(host->GetIntVal() != int_val);
         REQUIRE(host->GetIntVal() <= 1);
         REQUIRE(host->GetIntVal() >= -1);
@@ -192,7 +192,7 @@ TEST_CASE("Host Mutate", "[default]") {
         config.MUTATION_RATE(1);
         emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
         REQUIRE(host->GetIntVal() == int_val);
-        host->mutate();
+        host->Mutate();
         REQUIRE(host->GetIntVal() != int_val);
         REQUIRE(host->GetIntVal() <= 1);
         REQUIRE(host->GetIntVal() >= -1);
@@ -206,7 +206,7 @@ TEST_CASE("Host Mutate", "[default]") {
         config.MUTATION_SIZE(0);
         emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
         REQUIRE(host->GetIntVal() == int_val);
-        host->mutate();
+        host->Mutate();
         REQUIRE(host->GetIntVal() != int_val);
         REQUIRE(host->GetIntVal() <= 1);
         REQUIRE(host->GetIntVal() >= -1);
@@ -465,14 +465,14 @@ TEST_CASE("Host GrowOlder", "[default]"){
     }
 }
 
-TEST_CASE("Host makeNew", "[default]"){
+TEST_CASE("Host MakeNew", "[default]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     SymWorld w(*random);
     SymConfigBase config;
 
     double host_int_val = 0.2;
     emp::Ptr<Organism> host1 = emp::NewPtr<Host>(random, &w, &config, host_int_val);
-    emp::Ptr<Organism> host2 = host1->makeNew();
+    emp::Ptr<Organism> host2 = host1->MakeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
       REQUIRE(host1->GetIntVal() == host2->GetIntVal());
       REQUIRE(host2->GetPoints() == 0);
@@ -492,7 +492,7 @@ TEST_CASE("Host reproduce", "[default][efficient][lysis][pgg]"){
 
     double host_int_val = 0.2;
     emp::Ptr<Organism> host1 = emp::NewPtr<Host>(random, &w, &config, host_int_val);
-    emp::Ptr<Organism> host2 = host1->reproduce();
+    emp::Ptr<Organism> host2 = host1->Reproduce();
     THEN("The host baby has mutated interaction value"){
       REQUIRE(host1->GetIntVal() != host2->GetIntVal());
     }

--- a/source/test/default_mode_test/Host.test.cc
+++ b/source/test/default_mode_test/Host.test.cc
@@ -10,32 +10,36 @@ TEST_CASE("Host Constructor", "[default]") {
     SymWorld * world = &w;
 
     double int_val = -2;
-    REQUIRE_THROWS(new Host(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<Host>(random, world, &config, int_val) );
 
     int_val = -1;
-    Host * h1 = new Host(random, world, &config, int_val);
-    CHECK(h1->GetIntVal() == int_val);
-    CHECK(h1->GetAge() == 0); 
-    CHECK(h1->GetPoints() == 0);
+    emp::Ptr<Host> host1 = emp::NewPtr<Host>(random, world, &config, int_val);
+    CHECK(host1->GetIntVal() == int_val);
+    CHECK(host1->GetAge() == 0);
+    CHECK(host1->GetPoints() == 0);
 
     int_val = -1;
     emp::vector<emp::Ptr<Organism>> syms = {};
     emp::vector<emp::Ptr<Organism>> repro_syms = {};
     std::set<int> set = std::set<int>();
     double points = 10;
-    Host * h2 = new Host(random, world, &config, int_val, syms, repro_syms, set, points);
-    CHECK(h2->GetIntVal() == int_val);
-    CHECK(h2->GetAge() == 0);
-    CHECK(h2->GetPoints() == points);
+    emp::Ptr<Host> host2 = emp::NewPtr<Host>(random, world, &config, int_val, syms, repro_syms, set, points);
+    CHECK(host2->GetIntVal() == int_val);
+    CHECK(host2->GetAge() == 0);
+    CHECK(host2->GetPoints() == points);
 
     int_val = 1;
-    Host * h3 = new Host(random, world, &config, int_val);
-    CHECK(h3->GetIntVal() == int_val);
-    CHECK(h3->GetAge() == 0);
-    CHECK(h3->GetPoints() == 0);
+    emp::Ptr<Host> host3 = emp::NewPtr<Host>(random, world, &config, int_val);
+    CHECK(host3->GetIntVal() == int_val);
+    CHECK(host3->GetAge() == 0);
+    CHECK(host3->GetPoints() == 0);
 
     int_val = 2;
-    REQUIRE_THROWS(new Host(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<Host>(random, world, &config, int_val) );
+
+    host1.Delete();
+    host2.Delete();
+    host3.Delete();
 }
 
 TEST_CASE("Host SetIntVal, GetIntVal", "[default]") {
@@ -44,26 +48,28 @@ TEST_CASE("Host SetIntVal, GetIntVal", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
-    Host * h1 = new Host(random, &w, &config);
+    emp::Ptr<Host> host1 = emp::NewPtr<Host>(random, &w, &config);
     double default_int_val = 0.0;
-    REQUIRE(h1->GetIntVal() == default_int_val);
+    REQUIRE(host1->GetIntVal() == default_int_val);
 
-    Host * h2 = new Host(random, &w, &config, int_val);
+    emp::Ptr<Host> host2 = emp::NewPtr<Host>(random, &w, &config, int_val);
 
     double expected_int_val = 1;
-    REQUIRE(h2->GetIntVal() == expected_int_val);
+    REQUIRE(host2->GetIntVal() == expected_int_val);
 
     int_val = -0.7;
-    h2->SetIntVal(int_val);
+    host2->SetIntVal(int_val);
     expected_int_val = -0.7;
-    REQUIRE(h2->GetIntVal() == expected_int_val);
+    REQUIRE(host2->GetIntVal() == expected_int_val);
 
     int_val = -1.3;
-    REQUIRE_THROWS(new Host(random, &w, &config, int_val));
+    REQUIRE_THROWS(emp::NewPtr<Host>(random, &w, &config, int_val));
 
     int_val = 1.8;
-    REQUIRE_THROWS(new Host(random, &w, &config, int_val));
+    REQUIRE_THROWS(emp::NewPtr<Host>(random, &w, &config, int_val));
 
+    host1.Delete();
+    host2.Delete();
 }
 
 TEST_CASE("SetPoints, AddPoints, GetPoints", "[default]") {
@@ -72,18 +78,19 @@ TEST_CASE("SetPoints, AddPoints, GetPoints", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
-    Host * h = new Host(random, &w, &config, int_val);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
 
     double points = 50;
-    h->SetPoints(points);
+    host->SetPoints(points);
     double expected_points = 50;
-    REQUIRE(h->GetPoints() == expected_points);
+    REQUIRE(host->GetPoints() == expected_points);
 
     points = 76;
-    h->AddPoints(points);
+    host->AddPoints(points);
     expected_points = 126;
-    REQUIRE(h->GetPoints() == expected_points);
+    REQUIRE(host->GetPoints() == expected_points);
 
+    host.Delete();
 }
 
 TEST_CASE("SetResTypes, GetResTypes", "[default]") {
@@ -95,9 +102,9 @@ TEST_CASE("SetResTypes, GetResTypes", "[default]") {
     emp::vector<emp::Ptr<Organism>> repro_syms = {};
     std::set<int> res_types {1,3,5,9,2};
 
-    Host * h = new Host(random, &w, &config, int_val, syms, repro_syms, res_types);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val, syms, repro_syms, res_types);
 
-    std::set<int> expected_res_types = h->GetResTypes();
+    std::set<int> expected_res_types = host->GetResTypes();
     for (int number : res_types)
     {
         // Tests if each integer from res_types is in expected_res_types
@@ -105,14 +112,15 @@ TEST_CASE("SetResTypes, GetResTypes", "[default]") {
     }
 
     res_types = {0,1};
-    h->SetResTypes(res_types);
-    expected_res_types = h->GetResTypes();
+    host->SetResTypes(res_types);
+    expected_res_types = host->GetResTypes();
     for (int number : res_types)
     {
         // Tests if each integer from res_types is in expected_res_types
         REQUIRE(expected_res_types.find(number) != expected_res_types.end());
     }
 
+    host.Delete();
 }
 
 TEST_CASE("HasSym", "[default]") {
@@ -121,14 +129,22 @@ TEST_CASE("HasSym", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
+    emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
     WHEN("Host has no symbionts") {
-        Host * h = new Host(random, &w, &config, int_val);
-
         THEN("HasSym is false") {
             bool expected = false;
-            REQUIRE(h->HasSym() == expected);
+            REQUIRE(host->HasSym() == expected);
         }
     }
+
+    WHEN("Host has symbionts") {
+        host->AddSymbiont(emp::NewPtr<Symbiont>(random, &w, &config, int_val));
+        THEN("HasSym is true") {
+            bool expected = true;
+            REQUIRE(host->HasSym() == expected);
+        }
+    }
+    host.Delete();
 }
 
 TEST_CASE("Host Mutate", "[default]") {
@@ -143,25 +159,29 @@ TEST_CASE("Host Mutate", "[default]") {
       THEN("Normal mutation rate is used"){
         config.HOST_MUTATION_RATE(-1);
         config.MUTATION_RATE(1);
-        Host * h = new Host(random, &w, &config, int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
 
-        REQUIRE(h->GetIntVal() == int_val);
-        h->mutate();
-        REQUIRE(h->GetIntVal() != int_val);
-        REQUIRE(h->GetIntVal() <= 1);
-        REQUIRE(h->GetIntVal() >= -1);
+        REQUIRE(host->GetIntVal() == int_val);
+        host->mutate();
+        REQUIRE(host->GetIntVal() != int_val);
+        REQUIRE(host->GetIntVal() <= 1);
+        REQUIRE(host->GetIntVal() >= -1);
+
+        host.Delete();
       }
     }
     WHEN("Host mutation rate is not -1"){
       THEN("Host mutation rate is used"){
         config.HOST_MUTATION_RATE(1);
         config.MUTATION_RATE(0);
-        Host * h = new Host(random, &w, &config, int_val);
-        REQUIRE(h->GetIntVal() == int_val);
-        h->mutate();
-        REQUIRE(h->GetIntVal() != int_val);
-        REQUIRE(h->GetIntVal() <= 1);
-        REQUIRE(h->GetIntVal() >= -1);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+        REQUIRE(host->GetIntVal() == int_val);
+        host->mutate();
+        REQUIRE(host->GetIntVal() != int_val);
+        REQUIRE(host->GetIntVal() <= 1);
+        REQUIRE(host->GetIntVal() >= -1);
+
+        host.Delete();
       }
     }
 
@@ -170,28 +190,30 @@ TEST_CASE("Host Mutate", "[default]") {
       THEN("Normal mutation size is used"){
         config.HOST_MUTATION_SIZE(-1);
         config.MUTATION_RATE(1);
-        Host * h = new Host(random, &w, &config, int_val);
-        REQUIRE(h->GetIntVal() == int_val);
-        h->mutate();
-        REQUIRE(h->GetIntVal() != int_val);
-        REQUIRE(h->GetIntVal() <= 1);
-        REQUIRE(h->GetIntVal() >= -1);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+        REQUIRE(host->GetIntVal() == int_val);
+        host->mutate();
+        REQUIRE(host->GetIntVal() != int_val);
+        REQUIRE(host->GetIntVal() <= 1);
+        REQUIRE(host->GetIntVal() >= -1);
+
+        host.Delete();
       }
     }
     WHEN("Host mutation size is not -1"){
       THEN("Host mutation size is used"){
         config.HOST_MUTATION_SIZE(1);
         config.MUTATION_SIZE(0);
-        Host * h = new Host(random, &w, &config, int_val);
-        REQUIRE(h->GetIntVal() == int_val);
-        h->mutate();
-        REQUIRE(h->GetIntVal() != int_val);
-        REQUIRE(h->GetIntVal() <= 1);
-        REQUIRE(h->GetIntVal() >= -1);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+        REQUIRE(host->GetIntVal() == int_val);
+        host->mutate();
+        REQUIRE(host->GetIntVal() != int_val);
+        REQUIRE(host->GetIntVal() <= 1);
+        REQUIRE(host->GetIntVal() >= -1);
+
+        host.Delete();
       }
     }
-
-
 }
 
 TEST_CASE("DistributeResources", "[default]") {
@@ -206,15 +228,17 @@ TEST_CASE("DistributeResources", "[default]") {
         double orig_points = 0; // call this default_points instead? (i'm not setting this val)
         config.SYNERGY(5);
 
-        Host * h = new Host(random, &w, &config, int_val);
-        h->DistribResources(resources);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+        host->DistribResources(resources);
 
         THEN("Points increase") {
             double expected_points = resources - (resources * int_val); // 48
-            double points = h->GetPoints();
+            double points = host->GetPoints();
             REQUIRE(points == expected_points);
             REQUIRE(points > orig_points);
         }
+
+        host.Delete();
     }
 
     WHEN("There are no symbionts and interaction value is 0") {
@@ -224,14 +248,16 @@ TEST_CASE("DistributeResources", "[default]") {
         double orig_points = 0;
         config.SYNERGY(5);
 
-        Host * h = new Host(random, &w, &config, int_val);
-        h->DistribResources(resources);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+        host->DistribResources(resources);
 
         THEN("Resources are added to points") {
             double expected_points = orig_points + resources; // 0
-            double points = h->GetPoints();
+            double points = host->GetPoints();
             REQUIRE(points == expected_points);
         }
+
+        host.Delete();
     }
 
     WHEN("There are no symbionts and interaction value is between -1 and 0") {
@@ -241,18 +267,20 @@ TEST_CASE("DistributeResources", "[default]") {
         double orig_points = 27;
         config.SYNERGY(5);
 
-        Host * h = new Host(random, &w, &config, int_val);
-        h->AddPoints(orig_points);
-        h->DistribResources(resources);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+        host->AddPoints(orig_points);
+        host->DistribResources(resources);
 
         THEN("Points increase") {
             double host_defense =  -1.0 * int_val * resources; // the resources spent on defense
             double add_points  = resources - host_defense;
             double expected_points = orig_points + add_points;
-            double points = h->GetPoints();
+            double points = host->GetPoints();
             REQUIRE(points == expected_points);
             REQUIRE(points > orig_points);
         }
+
+        host.Delete();
     }
 }
 
@@ -262,14 +290,16 @@ TEST_CASE("SetResInProcess, GetResInProcess", "[default]") {
   SymWorld w(*random);
   double int_val = 1;
 
-  Host * h = new Host(random, &w, &config, int_val);
+  emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
 
   double expected_res_in_process = 0;
-  REQUIRE(h->GetResInProcess() == expected_res_in_process);
+  REQUIRE(host->GetResInProcess() == expected_res_in_process);
 
-  h->SetResInProcess(126);
+  host->SetResInProcess(126);
   expected_res_in_process = 126;
-  REQUIRE(h->GetResInProcess() == expected_res_in_process);
+  REQUIRE(host->GetResInProcess() == expected_res_in_process);
+
+  host.Delete();
 }
 
 TEST_CASE("Steal resources unit test", "[default]"){
@@ -283,46 +313,49 @@ TEST_CASE("Steal resources unit test", "[default]"){
 
         WHEN("host_int_val > 0"){
             double host_int_val = 0.2;
-            Host * h = new Host(random, &w, &config, host_int_val);
+            emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
-            h->SetResInProcess(100);
+            host->SetResInProcess(100);
             double expected_stolen = 60; // sym_int_val * res_in_process * -1
             double expected_res_in_process = 40; // res_in_process - expected_stolen
 
             THEN("Amount stolen is dependent only on sym_int_val"){
-                REQUIRE(h->StealResources(sym_int_val) == expected_stolen);
-                REQUIRE(h->GetResInProcess() == expected_res_in_process);
+                REQUIRE(host->StealResources(sym_int_val) == expected_stolen);
+                REQUIRE(host->GetResInProcess() == expected_res_in_process);
             }
+            host.Delete();
         }
         WHEN("host_int_val < 0"){
             double host_int_val = -0.2;
-            Host * h = new Host(random, &w, &config, host_int_val);
+            emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
-            h->SetResInProcess(100);
+            host->SetResInProcess(100);
             double expected_stolen = 40; // (host_int_val - sym_int_val) * res_in_process
             double expected_res_in_process = 60; // res_in_process - expected_stolen
 
             THEN("Amount stolen is dependent on both sym_int_val and host_int_val"){
-                REQUIRE(h->StealResources(sym_int_val) == expected_stolen);
-                REQUIRE(h->GetResInProcess() == expected_res_in_process);
+                REQUIRE(host->StealResources(sym_int_val) == expected_stolen);
+                REQUIRE(host->GetResInProcess() == expected_res_in_process);
             }
+            host.Delete();
         }
     }
 
     WHEN("host_int_val > sym_int_val"){
         double sym_int_val = -0.3;
         double host_int_val = -0.5;
-        Host * h = new Host(random, &w, &config, host_int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
-        h->SetResInProcess(100);
+        host->SetResInProcess(100);
         double expected_stolen = 0;
         double expected_res_in_process = 100;
 
-            THEN("Symbiont fails to steal resources"){
-                REQUIRE(h->StealResources(sym_int_val) == expected_stolen);
-                REQUIRE(h->GetResInProcess() == expected_res_in_process);
-            }
+        THEN("Symbiont fails to steal resources"){
+            REQUIRE(host->StealResources(sym_int_val) == expected_stolen);
+            REQUIRE(host->GetResInProcess() == expected_res_in_process);
         }
+        host.Delete();
+    }
 }
 
 TEST_CASE("GetDoEctosymbiosis", "[default]"){
@@ -336,8 +369,8 @@ TEST_CASE("GetDoEctosymbiosis", "[default]"){
 
     WHEN("Ectosymbiosis is off but other conditions are met"){
       config.ECTOSYMBIOSIS(0);
-      emp::Ptr<Host> host = new Host(random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
       w.AddOrgAt(host, host_pos);
       w.AddOrgAt(sym, emp::WorldPosition(0, host_pos));
       THEN("Returns false"){
@@ -346,8 +379,8 @@ TEST_CASE("GetDoEctosymbiosis", "[default]"){
     }
     WHEN("There is no parallel sym but other conditions are met"){
       config.ECTOSYMBIOSIS(1);
-      emp::Ptr<Host> host = new Host(random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
       w.AddOrgAt(host, host_pos);
       w.AddOrgAt(sym, emp::WorldPosition(0, host_pos + 1));
       THEN("Returns false"){
@@ -356,8 +389,8 @@ TEST_CASE("GetDoEctosymbiosis", "[default]"){
     }
     WHEN("There is a parallel sym but it is dead, and other conditions are met"){
       config.ECTOSYMBIOSIS(1);
-      emp::Ptr<Host> host = new Host(random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
       sym->SetDead();
       w.AddOrgAt(host, host_pos);
       w.AddOrgAt(sym, emp::WorldPosition(0, host_pos + 1));
@@ -368,9 +401,9 @@ TEST_CASE("GetDoEctosymbiosis", "[default]"){
     WHEN("Ectosymbiotic immunity is on and the host has a sym, but other conditions are met"){
       config.ECTOSYMBIOSIS(1);
       config.ECTOSYMBIOTIC_IMMUNITY(1);
-      emp::Ptr<Host> host = new Host(random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(random, &w, &config, int_val);
-      emp::Ptr<Organism> hosted_sym = new Symbiont(random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
+      emp::Ptr<Organism> hosted_sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
       w.AddOrgAt(host, host_pos);
       w.AddOrgAt(sym, emp::WorldPosition(0, host_pos));
       host->AddSymbiont(hosted_sym);
@@ -382,9 +415,9 @@ TEST_CASE("GetDoEctosymbiosis", "[default]"){
     WHEN("Ectosymbiosis is on, there is a parallel sym, ectosymbiotic immunity is off, and the host has a sym"){
       config.ECTOSYMBIOSIS(1);
       config.ECTOSYMBIOTIC_IMMUNITY(0);
-      emp::Ptr<Host> host = new Host(random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(random, &w, &config, int_val);
-      emp::Ptr<Organism> hosted_sym = new Symbiont(random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
+      emp::Ptr<Organism> hosted_sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
       w.AddOrgAt(host, host_pos);
       w.AddOrgAt(sym, emp::WorldPosition(0, host_pos));
       host->AddSymbiont(hosted_sym);
@@ -396,9 +429,9 @@ TEST_CASE("GetDoEctosymbiosis", "[default]"){
     WHEN("Ectosymbiosis is on, there is a parallel sym, ectosymbiotic immunity is on, and the host does not have a sym"){
       config.ECTOSYMBIOSIS(1);
       config.ECTOSYMBIOTIC_IMMUNITY(1);
-      emp::Ptr<Host> host = new Host(random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(random, &w, &config, int_val);
-      emp::Ptr<Organism> hosted_sym = new Symbiont(random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
+      
       w.AddOrgAt(host, host_pos);
       w.AddOrgAt(sym, emp::WorldPosition(0, host_pos));
 
@@ -416,16 +449,16 @@ TEST_CASE("Host GrowOlder", "[default]"){
     config.HOST_AGE_MAX(2);
 
     WHEN ("A host reaches its maximum age"){
-      Host * h = new Host(random, &w, &config, 1);
-      w.AddOrgAt(h, 1);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, 1);
+      w.AddOrgAt(host, 1);
       THEN("The host dies and is removed from the world"){
-        REQUIRE(h->GetDead() == false);
+        REQUIRE(host->GetDead() == false);
         REQUIRE(w.GetNumOrgs() == 1);
-        REQUIRE(h->GetAge() == 0);
+        REQUIRE(host->GetAge() == 0);
         w.Update();
-        REQUIRE(h->GetAge() == 1);
+        REQUIRE(host->GetAge() == 1);
         w.Update();
-        REQUIRE(h->GetAge() == 2);
+        REQUIRE(host->GetAge() == 2);
         w.Update();
         REQUIRE(w.GetNumOrgs() == 0);
       }
@@ -438,15 +471,18 @@ TEST_CASE("Host makeNew", "[default]"){
     SymConfigBase config;
 
     double host_int_val = 0.2;
-    Organism * h1 = new Host(random, &w, &config, host_int_val);
-    Organism * h2 = h1->makeNew();
+    emp::Ptr<Organism> host1 = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+    emp::Ptr<Organism> host2 = host1->makeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
-      REQUIRE(h1->GetIntVal() == h2->GetIntVal());
-      REQUIRE(h2->GetPoints() == 0);
-      REQUIRE(h2->GetAge() == 0);
+      REQUIRE(host1->GetIntVal() == host2->GetIntVal());
+      REQUIRE(host2->GetPoints() == 0);
+      REQUIRE(host2->GetAge() == 0);
       //check that the offspring is the correct class
-      REQUIRE(typeid(*h2).name() == typeid(*h1).name());
+      REQUIRE(typeid(*host2).name() == typeid(*host1).name());
     }
+
+    host1.Delete();
+    host2.Delete();
 }
 
 TEST_CASE("Host reproduce", "[default][efficient][lysis][pgg]"){
@@ -455,12 +491,15 @@ TEST_CASE("Host reproduce", "[default][efficient][lysis][pgg]"){
     SymConfigBase config;
 
     double host_int_val = 0.2;
-    Organism * h1 = new Host(random, &w, &config, host_int_val);
-    Organism * h2 = h1->reproduce();
+    emp::Ptr<Organism> host1 = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+    emp::Ptr<Organism> host2 = host1->reproduce();
     THEN("The host baby has mutated interaction value"){
-      REQUIRE(h1->GetIntVal() != h2->GetIntVal());
+      REQUIRE(host1->GetIntVal() != host2->GetIntVal());
     }
     THEN("The host parent's points are set to 0"){
-      REQUIRE(h1->GetPoints() == 0);
+      REQUIRE(host1->GetPoints() == 0);
     }
+
+    host1.Delete();
+    host2.Delete();
 }

--- a/source/test/default_mode_test/HostSymbiontUnitTest.test.cc
+++ b/source/test/default_mode_test/HostSymbiontUnitTest.test.cc
@@ -8,13 +8,15 @@ TEST_CASE("Symbiont SetHost, GetHost", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
-    emp::Ptr<Organism> h = new Host(random, &w, &config);
-    Symbiont * s = new Symbiont(random, &w, &config, int_val);
+    emp::Ptr<Organism> host = emp::NewPtr<Host>(random, &w, &config);
+    emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
 
-    s->SetHost(h);
+    symbiont->SetHost(host);
 
-    REQUIRE(s->GetHost() == h);
+    REQUIRE(symbiont->GetHost() == host);
 
+    symbiont.Delete();
+    host.Delete();
 }
 
 TEST_CASE("Host SetSymbionts", "[default]") {
@@ -24,29 +26,30 @@ TEST_CASE("Host SetSymbionts", "[default]") {
     double int_val = 1;
     config.SYM_LIMIT(2);
 
-    Host * h = new Host(random, &w, &config);
-    Symbiont * s1 = new Symbiont(random, &w, &config, int_val);
-    Symbiont * s2 = new Symbiont(random, &w, &config, int_val);
+    emp::Ptr<Organism> host = emp::NewPtr<Host>(random, &w, &config);
+    emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
 
     emp::vector<emp::Ptr<Organism>> syms;
-    syms.push_back(s1);
-    syms.push_back(s2);
+    syms.push_back(sym1);
+    syms.push_back(sym2);
 
-    h->SetSymbionts(syms);
+    host->SetSymbionts(syms);
 
-    REQUIRE(h->GetSymbionts().size() == syms.size());
+    REQUIRE(host->GetSymbionts().size() == syms.size());
 
     for(size_t i = 0; i < syms.size(); i++){
-        emp::vector<emp::Ptr<Organism>> host_syms = h->GetSymbionts();
-        Organism * curSym = host_syms[i];
-        Organism * curHost = curSym->GetHost();
-        REQUIRE(curSym == (Organism *) syms[i]);
-        REQUIRE(curHost == h);
+        emp::vector<emp::Ptr<Organism>> host_syms = host->GetSymbionts();
+        emp::Ptr<Organism> curSym = host_syms[i];
+        emp::Ptr<Organism> curHost = curSym->GetHost();
+        REQUIRE(curSym == (emp::Ptr<Organism>) syms[i]);
+        REQUIRE(curHost == host);
     }
 
     bool has_sym = true;
-    REQUIRE(h->HasSym() == has_sym);
+    REQUIRE(host->HasSym() == has_sym);
 
+    host.Delete();
 }
 
 TEST_CASE("Host SymLimit", "[default]") {
@@ -56,31 +59,30 @@ TEST_CASE("Host SymLimit", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
-    Host * h = new Host(random, &w, &config);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config);
 
-    emp::Ptr<Symbiont> s1;
-    s1.New(random, &w, &config, int_val);
-    emp::Ptr<Symbiont> s2;
-    s2.New(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym1;
+    sym1.New(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym2;
+    sym2.New(random, &w, &config, int_val);
 
     emp::vector<emp::Ptr<Organism>> syms;
 
-    syms.push_back(s1);
-    h->AddSymbiont(s1);
-    REQUIRE(h->GetSymbionts() == syms);
+    syms.push_back(sym1);
+    host->AddSymbiont(sym1);
+    REQUIRE(host->GetSymbionts() == syms);
 
     WHEN("A symbiont is added once the SymLimit has been reached ") {
-        h->AddSymbiont(s2);
+        host->AddSymbiont(sym2);
 
         THEN("The symbiont is not added to the host's syms") {
-            REQUIRE(h->GetSymbionts() == syms); // s2 is not added, sym limit was reached
+            REQUIRE(host->GetSymbionts() == syms); // sym2 is not added, sym limit was reached
 
         }
 
     }
     random.Delete();
-    s1.Delete();
-
+    host.Delete();
 }
 
 TEST_CASE("Host AddSymbiont", "[default]") {
@@ -90,23 +92,25 @@ TEST_CASE("Host AddSymbiont", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
-    Host * h = new Host(random, &w, &config);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config);
 
-    Symbiont * s1 = new Symbiont(random, &w, &config, int_val);
-    Symbiont * s2 = new Symbiont(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
 
     emp::vector<emp::Ptr<Organism>> syms;
 
-    syms.push_back(s1);
-    h->AddSymbiont(s1);
+    syms.push_back(sym1);
+    host->AddSymbiont(sym1);
 
-    REQUIRE(h->GetSymbionts() == syms);
+    REQUIRE(host->GetSymbionts() == syms);
     bool has_sym = true;
-    REQUIRE(h->HasSym() == has_sym);
+    REQUIRE(host->HasSym() == has_sym);
 
-    h->AddSymbiont(s2);
-    syms.push_back(s2);
-    REQUIRE(h->GetSymbionts() == syms);
+    host->AddSymbiont(sym2);
+    syms.push_back(sym2);
+    REQUIRE(host->GetSymbionts() == syms);
+
+    host.Delete();
 }
 
 TEST_CASE("Host AddReproSym, ClearReproSym, GetReproSymbionts", "[default]") {
@@ -116,26 +120,30 @@ TEST_CASE("Host AddReproSym, ClearReproSym, GetReproSymbionts", "[default]") {
     SymWorld w(*random);
     double int_val = 1;
 
-    Host * h = new Host(random, &w, &config);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config);
 
-    Symbiont * s1 = new Symbiont(random, &w, &config, int_val);
-    Symbiont * s2 = new Symbiont(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
+    emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, int_val);
 
     emp::vector<emp::Ptr<Organism>> repro_syms;
 
-    repro_syms.push_back(s1);
-    h->AddReproSym(s1);
+    repro_syms.push_back(sym1);
+    host->AddReproSym(sym1);
 
-    REQUIRE(h->GetReproSymbionts() == repro_syms);
+    REQUIRE(host->GetReproSymbionts() == repro_syms);
 
-    repro_syms.push_back(s2);
-    h->AddReproSym(s2);
+    repro_syms.push_back(sym2);
+    host->AddReproSym(sym2);
 
-    REQUIRE(h->GetReproSymbionts() == repro_syms);
+    REQUIRE(host->GetReproSymbionts() == repro_syms);
 
-    h->ClearReproSyms();
+    host->ClearReproSyms();
     repro_syms.clear();
-    REQUIRE(h->GetReproSymbionts() == repro_syms);
+    REQUIRE(host->GetReproSymbionts() == repro_syms);
+
+    host.Delete();
+    sym1.Delete();
+    sym2.Delete();
 }
 
 TEST_CASE("Host DistribResources", "[default]") {
@@ -150,17 +158,17 @@ TEST_CASE("Host DistribResources", "[default]") {
         double host_int_val = 0.5;
         double sym_int_val = 1;
 
-        Host * h = new Host(random, &w, &config, host_int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
 
-        Symbiont * s1 = new Symbiont(random, &w, &config, sym_int_val);
-        Symbiont * s2 = new Symbiont(random, &w, &config, sym_int_val);
-        Symbiont * s3 = new Symbiont(random, &w, &config, sym_int_val);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+        emp::vector<emp::Ptr<Organism>> syms = {sym1, sym2, sym3};
+        host->SetSymbionts(syms);
 
         double resources = 120;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
 
         int num_syms = 3;
@@ -180,29 +188,31 @@ TEST_CASE("Host DistribResources", "[default]") {
             for( emp::Ptr<Organism> symbiont : syms) {
                 REQUIRE(symbiont->GetPoints() == sym_points);
             }
-            REQUIRE(h->GetPoints() == host_points);
+            REQUIRE(host->GetPoints() == host_points);
         }
+        host.Delete();
     }
 
 
     WHEN("Host interaction value <= 0 and Symbiont interaction value < 0") {
-        double host_int_val = -0.5;
-        double sym_int_val = -0.1;
-        double host_orig_points = 0;
-        double sym_orig_points = 0;
-
-        Host * h = new Host(random, &w, &config, host_int_val);
-
-
-        Symbiont * s1 = new Symbiont(random, &w, &config, sym_int_val);
-        Symbiont * s2 = new Symbiont(random, &w, &config, sym_int_val);
-        Symbiont * s3 = new Symbiont(random, &w, &config, sym_int_val);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
 
         WHEN("Host interaction value < Symbionts' interaction value") {
+            double host_int_val = -0.5;
+            double sym_int_val = -0.1;
+            double host_orig_points = 0;
+            double sym_orig_points = 0;
+
+            emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+
+
+            emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+            emp::vector<emp::Ptr<Organism>> syms = {sym1, sym2, sym3};
+            host->SetSymbionts(syms);
+
             double resources = 120;
-            h->DistribResources(resources);
+            host->DistribResources(resources);
 
             int num_syms = 3;
             double sym_piece = resources / num_syms; // how much resource each sym gets
@@ -214,11 +224,11 @@ TEST_CASE("Host DistribResources", "[default]") {
                 for( emp::Ptr<Organism> symbiont : syms) {
                     REQUIRE(symbiont->GetPoints() == sym_orig_points);
                 }
-                REQUIRE(h->GetPoints() == host_points);
-                REQUIRE(h->GetPoints() > host_orig_points);
+                REQUIRE(host->GetPoints() == host_points);
+                REQUIRE(host->GetPoints() > host_orig_points);
             }
+            host.Delete();
         }
-
 
         WHEN("Host interaction value > Symbionts' interaction value") {
             double host_int_val = -0.2;
@@ -226,17 +236,17 @@ TEST_CASE("Host DistribResources", "[default]") {
             double host_orig_points = 0;
             double sym_orig_points = 0;
 
-            Host * h = new Host(random, &w, &config, host_int_val);
+            emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
 
-            Symbiont * s1 = new Symbiont(random, &w, &config, sym_int_val);
-            Symbiont * s2 = new Symbiont(random, &w, &config, sym_int_val);
-            Symbiont * s3 = new Symbiont(random, &w, &config, sym_int_val);
-            emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-            h->SetSymbionts(syms);
+            emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+            emp::vector<emp::Ptr<Organism>> syms = {sym1, sym2, sym3};
+            host->SetSymbionts(syms);
 
             double resources = 120;
-            h->DistribResources(resources);
+            host->DistribResources(resources);
 
             int num_syms = 3;
             double sym_piece = resources / num_syms; // how much resource each sym gets
@@ -251,9 +261,10 @@ TEST_CASE("Host DistribResources", "[default]") {
                     REQUIRE(symbiont->GetPoints() == sym_points);
                     REQUIRE(symbiont->GetPoints() > sym_orig_points);
                 }
-                REQUIRE(h->GetPoints() == host_points);
-                REQUIRE(h->GetPoints() > host_orig_points);
+                REQUIRE(host->GetPoints() == host_points);
+                REQUIRE(host->GetPoints() > host_orig_points);
             }
+            host.Delete();
         }
     }
     WHEN("Host interaction value > 0 and Symbiont interaction value < 0, single symbiont") {
@@ -262,12 +273,12 @@ TEST_CASE("Host DistribResources", "[default]") {
         double host_orig_points = 0;
         double sym_orig_points = 0;
 
-        Host * h = new Host(random, &w, &config, host_int_val);
-        Symbiont * s = new Symbiont(random, &w, &config, sym_int_val, sym_orig_points);
-        h->AddSymbiont(s);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+        emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        host->AddSymbiont(symbiont);
 
         int resources = 100;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
         // int host_donation = 10; //host_int_val * resources
         int host_portion = 90;  //remaining amount
@@ -276,10 +287,10 @@ TEST_CASE("Host DistribResources", "[default]") {
         host_portion = host_portion - sym_steals; //remove stolen resources from host's portion
 
         THEN("Symbionts points and Host points increase the correct amounts") {
-            REQUIRE(s->GetPoints() == sym_orig_points+sym_portion);
-            REQUIRE(h->GetPoints() == host_orig_points+host_portion);
+            REQUIRE(symbiont->GetPoints() == sym_orig_points+sym_portion);
+            REQUIRE(host->GetPoints() == host_orig_points+host_portion);
         }
-
+        host.Delete();
     }
     WHEN("Host interaction value > 0 and Symbiont interaction value < 0, multiple symbionts") {
         double host_int_val = 0.1;
@@ -287,17 +298,17 @@ TEST_CASE("Host DistribResources", "[default]") {
         double host_orig_points = 0;
         double sym_orig_points = 0;
 
-        Host * h = new Host(random, &w, &config, host_int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
 
-        Symbiont * s1 = new Symbiont(random, &w, &config, sym_int_val, sym_orig_points);
-        Symbiont * s2 = new Symbiont(random, &w, &config, sym_int_val, sym_orig_points);
-        Symbiont * s3 = new Symbiont(random, &w, &config, sym_int_val, sym_orig_points);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::vector<emp::Ptr<Organism>> syms = {sym1, sym2, sym3};
+        host->SetSymbionts(syms);
 
         double resources = 120;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
 
         int num_syms = 3;
@@ -320,10 +331,10 @@ TEST_CASE("Host DistribResources", "[default]") {
                REQUIRE(symbiont->GetPoints() > sym_orig_points);
             }
 
-            REQUIRE(h->GetPoints() == host_final_portion);
-            REQUIRE(h->GetPoints() > host_orig_points);
+            REQUIRE(host->GetPoints() == host_final_portion);
+            REQUIRE(host->GetPoints() > host_orig_points);
         }
-
+        host.Delete();
     }
 
 
@@ -333,17 +344,17 @@ TEST_CASE("Host DistribResources", "[default]") {
         double host_orig_points = 0;
         double symbiont_orig_points = 0;
 
-        Host * h = new Host(random, &w, &config, host_int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
 
 
-        Symbiont * s1 = new Symbiont(random, &w, &config, sym_int_val);
-        Symbiont * s2 = new Symbiont(random, &w, &config, sym_int_val);
-        Symbiont * s3 = new Symbiont(random, &w, &config, sym_int_val);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+        emp::vector<emp::Ptr<Organism>> syms = {sym1, sym2, sym3};
+        host->SetSymbionts(syms);
 
         double resources = 120;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
         int num_syms = 3;
         double sym_piece = resources / num_syms;
@@ -359,10 +370,11 @@ TEST_CASE("Host DistribResources", "[default]") {
                 REQUIRE(symbiont->GetPoints() == sym_points);
                 REQUIRE(symbiont->GetPoints() == symbiont_orig_points);
             }
-            REQUIRE(h->GetPoints() == host_points);
-            REQUIRE(h->GetPoints() > host_orig_points);
+            REQUIRE(host->GetPoints() == host_points);
+            REQUIRE(host->GetPoints() > host_orig_points);
 
         }
+        host.Delete();
     }
 }
 
@@ -381,37 +393,43 @@ TEST_CASE("Vertical Transmission of Symbiont", "[default]") {
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<Host> h = new Host(random, world, &config, host_int_val);
-        emp::Ptr<Symbiont> s = new Symbiont(random, world, &config, sym_int_val);
-        s->AddPoints(points_recieved);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, world, &config, host_int_val);
+        emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(random, world, &config, sym_int_val);
+        symbiont->AddPoints(points_recieved);
 
-        emp::Ptr<Host> host_baby = emp::NewPtr<Host>(random, world, &config, h->GetIntVal());
+        emp::Ptr<Host> host_baby = emp::NewPtr<Host>(random, world, &config, host->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size() + 1;
-        s->VerticalTransmission(host_baby);
+        symbiont->VerticalTransmission(host_baby);
 
         THEN("Symbiont offspring are injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
 
         THEN("Symbiont parent has lost the points needed for reproduction and is down to 0") {
-            REQUIRE(s->GetPoints() == 0);
+            REQUIRE(symbiont->GetPoints() == 0);
         }
+        symbiont.Delete();
+        host.Delete();
+        host_baby.Delete();
     }
     WHEN("When vertical transmission is disabled"){
         world->SetVertTrans(0);
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<Host> h = new Host(random, world, &config, host_int_val);
-        emp::Ptr<Symbiont> s = new Symbiont(random, world, &config, sym_int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, world, &config, host_int_val);
+        emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(random, world, &config, sym_int_val);
 
-        emp::Ptr<Host> host_baby = emp::NewPtr<Host>(random, world, &config, h->GetIntVal());
+        emp::Ptr<Host> host_baby = emp::NewPtr<Host>(random, world, &config, host->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size();
-        s->VerticalTransmission(host_baby);
+        symbiont->VerticalTransmission(host_baby);
 
         THEN("Symbiont offspring are not injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
+        symbiont.Delete();
+        host.Delete();
+        host_baby.Delete();
     }
     WHEN("When the sym does not have enough resources to transmit"){
         world->SetVertTrans(1);
@@ -420,18 +438,22 @@ TEST_CASE("Vertical Transmission of Symbiont", "[default]") {
         double points_recieved = points_required - 1;
         config.SYM_VERT_TRANS_RES(points_required);
 
-        emp::Ptr<Host> h = new Host(random, world, &config, int_val);
-        emp::Ptr<Symbiont> s = new Symbiont(random, world, &config, int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, world, &config, int_val);
+        emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
-        s->AddPoints(points_recieved);
+        symbiont->AddPoints(points_recieved);
 
-        emp::Ptr<Host> host_baby = emp::NewPtr<Host>(random, world, &config, h->GetIntVal());
+        emp::Ptr<Host> host_baby = emp::NewPtr<Host>(random, world, &config, host->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size();
-        s->VerticalTransmission(host_baby);
+        symbiont->VerticalTransmission(host_baby);
 
         THEN("Symbiont offspring are not injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
+
+        symbiont.Delete();
+        host.Delete();
+        host_baby.Delete();
     }
 }
 
@@ -448,8 +470,8 @@ TEST_CASE("HandleEctosymbiosis"){
   WHEN("Ectosymbiosis is off"){
     config.ECTOSYMBIOSIS(0);
 
-    emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
-    emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+    emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
     w.AddOrgAt(sym,0);
     w.AddOrgAt(host,0);
     REQUIRE(sym->GetPoints() == 0);
@@ -472,8 +494,8 @@ TEST_CASE("HandleEctosymbiosis"){
     config.ECTOSYMBIOSIS(1);
 
     WHEN("There is no endosymbiont, only ectosymbiont"){
-      emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
-      emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
       w.AddOrgAt(sym,0);
       w.AddOrgAt(host,0);
@@ -501,9 +523,9 @@ TEST_CASE("HandleEctosymbiosis"){
       config.ECTOSYMBIOTIC_IMMUNITY(0);
       config.SYNERGY(synergy);
 
-      emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
-      emp::Ptr<Organism> parallel_sym = new Symbiont(&random, &w, &config, int_val);
-      emp::Ptr<Organism> hosted_sym = new Symbiont(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+      emp::Ptr<Organism> parallel_sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+      emp::Ptr<Organism> hosted_sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
       w.AddOrgAt(parallel_sym,0);
       w.AddOrgAt(host,0);
@@ -534,9 +556,9 @@ TEST_CASE("HandleEctosymbiosis"){
     WHEN("A hosted sym confers immunity to ectosymbiosis"){
       config.ECTOSYMBIOTIC_IMMUNITY(1);
 
-      emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
-      emp::Ptr<Organism> parallel_sym = new Symbiont(&random, &w, &config, int_val);
-      emp::Ptr<Organism> hosted_sym = new Symbiont(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
+      emp::Ptr<Organism> parallel_sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+      emp::Ptr<Organism> hosted_sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
       w.AddOrgAt(parallel_sym,0);
       w.AddOrgAt(host,0);
@@ -567,7 +589,7 @@ TEST_CASE("HandleEctosymbiosis"){
 
       config.ECTOSYMBIOSIS(1);
 
-      emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host,0);
       REQUIRE(host->GetPoints() == 0);
 

--- a/source/test/default_mode_test/SymWorld.test.cc
+++ b/source/test/default_mode_test/SymWorld.test.cc
@@ -1093,7 +1093,6 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
   }
 }
 
-
 TEST_CASE( "Symbiont Phylogeny", "[default]" ){
   emp::Random random(17);
   SymConfigBase config;

--- a/source/test/default_mode_test/SymWorld.test.cc
+++ b/source/test/default_mode_test/SymWorld.test.cc
@@ -1154,7 +1154,7 @@ TEST_CASE( "Symbiont Phylogeny", "[default]" ){
     w.AddSymToSystematic(syms[0]);
 
     for(size_t i = 1; i < num_syms; i++){
-      syms[i] = syms[i-1]->reproduce();
+      syms[i] = syms[i-1]->Reproduce();
     }
 
     THEN("Their lineages are tracked"){

--- a/source/test/default_mode_test/SymWorld.test.cc
+++ b/source/test/default_mode_test/SymWorld.test.cc
@@ -130,9 +130,11 @@ TEST_CASE( "Interaction Patterns", "[default]" ) {
         emp::Ptr<Host> new_org = emp::NewPtr<Host>(random, &w, &config, -0.1);
         w.AddOrgAt(new_org, w.size());
       }
-
-      w.Resize(10, 1);
-      for (size_t i = 0; i< 10; i++){
+      int width = 10;
+      int height = 1;
+      int world_size = width * height;
+      w.Resize(width, height);
+      for (int i = 0; i < world_size; i++){
         emp::Ptr<Symbiont> new_sym = emp::NewPtr<Symbiont>(random, &w, &config, 0.1);
         w.InjectSymbiont(new_sym);
       }
@@ -175,7 +177,9 @@ TEST_CASE( "Interaction Patterns", "[default]" ) {
         w.AddOrgAt(new_org, w.size());
       }
 
-      w.Resize(100, 200);
+      int width = 100;
+      int height = 200;
+      w.Resize(width, height);
 
       for (size_t i = 0; i < 10000; i++){
         emp::Ptr<Symbiont> new_sym;
@@ -247,7 +251,8 @@ TEST_CASE( "Interaction Patterns", "[default]" ) {
     config.RES_DISTRIBUTE(100);
     config.SYNERGY(5);
     config.PGG(1);
-    w.Resize(100, 200);
+    int world_size = 20000;
+    w.Resize(world_size);
 
 
     WHEN( "very generous hosts meet many very hostile symbionts" ) {
@@ -321,15 +326,16 @@ TEST_CASE( "InjectSymbiont", "[default]" ){
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
+    int world_size = 4;
 
     WHEN( "free living syms are not allowed" ){
+      w.Resize(world_size);
       config.FREE_LIVING_SYMS(0);
       w.SetFreeLivingSyms(false);
 
-      emp::Ptr<Organism> host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Organism> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
-      emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+      emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
       THEN( "syms are injected into a random host" ){
         w.InjectSymbiont(sym);
@@ -340,7 +346,8 @@ TEST_CASE( "InjectSymbiont", "[default]" ){
       }
     }
     WHEN( "free living syms are allowed" ){
-      w.Resize(1000);
+      world_size = 1000;
+      w.Resize(world_size);
       config.FREE_LIVING_SYMS(1);
       w.SetFreeLivingSyms(true);
 
@@ -352,7 +359,7 @@ TEST_CASE( "InjectSymbiont", "[default]" ){
         size_t sym_count = 100;
 
         for(size_t i = 0; i < sym_count; i++){
-          w.InjectSymbiont(new Symbiont(&random, &w, &config, int_val));
+          w.InjectSymbiont(emp::NewPtr<Symbiont>(&random, &w, &config, int_val));
         }
         //since spot of injection is random, a few symbionts
         //will get overwritten, and thus # injected != # remaining in world
@@ -369,11 +376,12 @@ TEST_CASE( "DoBirth", "[default]" ){
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
+    int world_size = 4;
+    w.Resize(world_size);
     w.SetFreeLivingSyms(true);
-    emp::Ptr<Organism> h2 = new Host(&random, &w, &config, int_val);
+    emp::Ptr<Organism> h2 = emp::NewPtr<Host>(&random, &w, &config, int_val);
     w.AddOrgAt(h2, 3);
-    emp::Ptr<Organism> host = new Host(&random, &w, &config, int_val);
+    emp::Ptr<Organism> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
 
     WHEN( "born into an empty spot" ){
       THEN( "occupies that spot" ){
@@ -392,7 +400,7 @@ TEST_CASE( "DoBirth", "[default]" ){
     }
     WHEN( "born into a spot occupied by another host" ){
       THEN( "kills that host and replaces it" ){
-        emp::Ptr<Organism> other_host = new Host(&random, &w, &config, int_val);
+        emp::Ptr<Organism> other_host = emp::NewPtr<Host>(&random, &w, &config, int_val);
         w.AddOrgAt(other_host, 0);
         w.DoBirth(host, 2);
 
@@ -421,17 +429,18 @@ TEST_CASE( "SymDoBirth", "[default]" ) {
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
+    size_t world_size = 4;
+    w.Resize(world_size);
 
     WHEN( "free living symbionts are not allowed" ) {
       config.FREE_LIVING_SYMS(0);
       w.SetFreeLivingSyms(false);
 
       WHEN( "there is a valid neighbouring host" ){
-        emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
         w.AddOrgAt(host, 0);
 
-        emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
         w.SymDoBirth(sym, 1);
 
         emp::vector<emp::Ptr<Organism>> syms = host->GetSymbionts();
@@ -444,7 +453,7 @@ TEST_CASE( "SymDoBirth", "[default]" ) {
       }
 
       WHEN( "there is no valid neighbouring host" ){
-        emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
         w.SymDoBirth(sym, 1);
 
         THEN( "the sym is killed" ){
@@ -458,61 +467,34 @@ TEST_CASE( "SymDoBirth", "[default]" ) {
     WHEN( "free living symbionts are allowed"){
       config.FREE_LIVING_SYMS(1);
       w.SetFreeLivingSyms(true);
-      config.SYM_LIMIT(3);
 
-      emp::Ptr<Organism> host1 = new Host(&random, &w, &config, int_val);
-
-      emp::Ptr<Organism> sym1 = new Symbiont(&random, &w, &config, int_val);
-      emp::Ptr<Organism> sym2 = new Symbiont(&random, &w, &config, int_val);
-
-      WHEN("sym is inserted into an empty world"){
-        THEN("it occupies some empty cell"){
-          emp::WorldPosition parent_pos = emp::WorldPosition(3, 3);
-          w.AddOrgAt(new Symbiont(&random, &w, &config, int_val), parent_pos);
-          w.SymDoBirth(sym1, parent_pos);
-          REQUIRE(w.GetNumOrgs() == 2);
-        }
+      THEN("it might be inserted into an empty cell"){
+        w.SymDoBirth(emp::NewPtr<Symbiont>(&random, &w, &config, int_val), emp::WorldPosition(0, 1));
+        REQUIRE(w.GetNumOrgs() == 1);
       }
-      WHEN("sym is inserted into a not-empty world"){
-        THEN("it might be inserted into an empty cell"){
-          w.AddOrgAt(host1, 0);
-          w.SymDoBirth(sym1, 2);
 
-          REQUIRE(w.GetNumOrgs() == 2);
+      THEN("it may be inserted into an occupied cell, overwriting the previous occupant"){
+        world_size = 2;
+        w.Resize(world_size);
 
-          bool sym_injected = false;
-          for(size_t i = 0; i < 4; i++){
-            if(w.GetSymPop()[i] == sym1) {
-              sym_injected = true;
-              break;
-            }
-          }
-          REQUIRE(sym_injected == true);
+        for(size_t i = 0; i < world_size; i++){
+          w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, int_val), emp::WorldPosition(0, i));
         }
-        THEN("it might be insterted into a cell with a sym, killing and replacing it"){
-          w.Resize(2,1);
-          w.AddOrgAt(sym1, 0);
-          w.AddOrgAt(sym2, emp::WorldPosition(0, 1));
+        REQUIRE(w.GetNumOrgs() == world_size);
 
-          emp::Ptr<Organism> new_sym = new Symbiont(&random, &w, &config, int_val);
+        emp::WorldPosition parent_pos = emp::WorldPosition(0, 1);
+        emp::Ptr<Organism> new_symbiont = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+        w.SymDoBirth(new_symbiont, parent_pos);
 
-          w.SymDoBirth(new_sym, 0);
-
-          REQUIRE(w.GetNumOrgs() == 2);
-
-          bool new_sym_born = false;
-          bool sym1_deleted = true;
-          bool sym2_deleted = true;
-          for(size_t i = 0; i < 2; i++){
-            emp::Ptr<Organism> element = w.GetSymPop()[i];
-            if(element == new_sym) new_sym_born = true;
-            else if(element == sym1) sym1_deleted = false;
-            else if(element == sym2) sym2_deleted = false;
+        bool new_sym_born = false;
+        for(size_t i = 0; i < world_size; i++){
+          if(w.GetSymAt(i) == new_symbiont){
+            new_sym_born = true;
           }
-
-          REQUIRE(new_sym_born == true);
-          REQUIRE(sym1_deleted != sym2_deleted); //Only one sym should be deleted
         }
+
+        REQUIRE(w.GetNumOrgs() == world_size);
+        REQUIRE(new_sym_born == true);
       }
     }
   }
@@ -524,11 +506,13 @@ TEST_CASE( "Update", "[default]" ){
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
-    int resPerUpdate = 10;
-    config.RES_DISTRIBUTE(resPerUpdate);
+    int world_size = 4;
+    w.Resize(world_size);
+    int res_per_update = 10;
+    config.RES_DISTRIBUTE(res_per_update);
+    int num_updates = 5;
 
-    emp::Ptr<Host> host = new Host(&random, &w, &config, int_val);
+    emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
 
     WHEN("free living syms are not allowed"){
       w.AddOrgAt(host, 0);
@@ -543,71 +527,72 @@ TEST_CASE( "Update", "[default]" ){
         }
       }
       THEN("hosts process normally"){
-        int resBeforeUpdate = host->GetPoints();
+        int res_before_update = host->GetPoints();
         w.Update();
-        int resAfterUpdate = host->GetPoints();
-        int resChange = resAfterUpdate - resBeforeUpdate;
-        REQUIRE(resPerUpdate == resChange);
+        int res_after_update = host->GetPoints();
+        int res_change = res_after_update - res_before_update;
+        REQUIRE(res_per_update == res_change);
       }
     }
 
 
     WHEN("free living syms are allowed"){
-      int resPerUpdate = 80;
-      config.RES_DISTRIBUTE(resPerUpdate);
-      config.FREE_SYM_RES_DISTRIBUTE(resPerUpdate);
-      w.Resize(4,4);
+      res_per_update = 80;
+      config.RES_DISTRIBUTE(res_per_update);
+      config.FREE_SYM_RES_DISTRIBUTE(res_per_update);
+      world_size = 16;
+      w.Resize(world_size);
       w.SetFreeLivingSyms(1);
       config.FREE_LIVING_SYMS(1);
       config.MOVE_FREE_SYMS(1);
 
       WHEN("there are no syms in the world"){
         THEN("hosts process normally"){
-          host = new Host(&random, &w, &config, int_val);
           w.AddOrgAt(host, 0);
           int orig_points = host->GetPoints();
           w.Update();
 
-          REQUIRE(host->GetPoints() - orig_points == resPerUpdate);
+          REQUIRE(host->GetPoints() - orig_points == res_per_update);
         }
       }
 
       WHEN("lysis is permitted, and thus phage are used"){
         LysisWorld lw(random);
-        lw.Resize(4,4);
+        lw.Resize(world_size);
         lw.SetFreeLivingSyms(1);
-
         config.LYSIS(1);
         config.LYSIS_CHANCE(1);
         int burst_time = 2;
         config.BURST_TIME(burst_time);
-        emp::Ptr<Organism> p = new Phage(&random, &lw, &config, int_val);
+
+        emp::Ptr<Organism> phage = emp::NewPtr<Phage>(&random, &lw, &config, int_val);
 
         WHEN("there are no hosts"){
           THEN("phage don't reproduce or get points on update"){
-            lw.AddOrgAt(p, 0);
+            lw.AddOrgAt(phage, emp::WorldPosition(0, 0));
 
             int orig_num_orgs = lw.GetNumOrgs();
-            int orig_points = p->GetPoints();
+            int orig_points = phage->GetPoints();
 
-            for(int i = 0; i < 4; i ++){
+            for(int i = 0; i < num_updates; i ++){
               lw.Update();
             }
 
             int new_num_orgs = lw.GetNumOrgs();
-            int new_points = p->GetPoints();
+            int new_points = phage->GetPoints();
 
             REQUIRE(new_num_orgs == orig_num_orgs);
             REQUIRE(new_points == orig_points);
           }
+          host.Delete(); //because it wasn't added to the world, it has to be deleted manually
         }
 
         WHEN("there are hosts"){
           THEN("phage and hosts mingle in the world"){
             lw.AddOrgAt(host, 0);
-            lw.AddOrgAt(p, emp::WorldPosition(0,1));
+            lw.AddOrgAt(phage, emp::WorldPosition(0,1));
 
-            for(int i = 0; i < 5; i++){
+            for(int i = 0; i < num_updates; i++){
               lw.Update();
             }
 
@@ -619,27 +604,36 @@ TEST_CASE( "Update", "[default]" ){
       WHEN("lysis is not permitted, and symbionts are used"){
         config.LYSIS(0);
         config.HORIZ_TRANS(1);
-        w.Resize(3,3);
+        world_size = 9;
+        w.Resize(world_size);
 
         THEN("if only syms in the world they can get resources and reproduce"){
-          emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+          emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
           w.SymDoBirth(sym, 0);
           REQUIRE(w.GetNumOrgs() == 1);
 
-          for(int i = 0; i <= 4; i++){
+          for(int i = 0; i < num_updates; i++){
             w.Update();
           }
           //the sym has reproduced at least once
           REQUIRE(w.GetNumOrgs() > 1);
 
           int num_pop_elements = 0;
-          for(int i = 0; i < 9; i++) if(w.GetPop()[i]) num_pop_elements++;
+          for(int i = 0; i < world_size; i++){
+            if(w.GetPop()[i]){
+              num_pop_elements++;
+            }
+          }
           REQUIRE(num_pop_elements == 0);
+
+          host.Delete(); //since it wasn't added to the world, have to delete it manually
         }
         THEN("hosts and syms can mingle in the environment"){
           w.AddOrgAt(host, 0);
-          w.AddOrgAt(new Symbiont(&random, &w, &config, int_val), emp::WorldPosition(0,1));
-          for(int i = 0; i <= 4; i++){ w.Update(); }
+          w.AddOrgAt(emp::NewPtr<Symbiont>(&random, &w, &config, int_val), emp::WorldPosition(0,1));
+          for(int i = 0; i < num_updates; i++){
+            w.Update();
+          }
 
           //the organisms have done something
           REQUIRE(w.GetNumOrgs() > 2);
@@ -647,12 +641,14 @@ TEST_CASE( "Update", "[default]" ){
           int free_sym_count = 0;
           int hosted_sym_count = 0;
           int host_count = 0;
-          for(int i = 0; i < 9; i++){
+          for(int i = 0; i < world_size; i++){
             if(w.GetPop()[i]){
               host_count++;
               hosted_sym_count += w.GetOrg(i).GetSymbionts().size();
             }
-            if(w.GetSymPop()[i]) free_sym_count++;
+            if(w.GetSymPop()[i]){
+              free_sym_count++;
+            }
           }
           //there should be at least one free sym, hosted sym, and host
           REQUIRE(free_sym_count > 0);
@@ -671,21 +667,22 @@ TEST_CASE( "MoveFreeSym", "[default]" ){
     SymWorld w(random);
     w.SetFreeLivingSyms(true);
     int int_val = 0;
-    w.Resize(2,2);
+    int world_size = 4;
+    w.Resize(world_size);
     size_t host_pos = 0;
     emp::WorldPosition sym_pos = emp::WorldPosition(0, host_pos);
 
-    emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+    emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
     w.AddOrgAt(sym, sym_pos);
     WHEN("there is a parallel host and the sym wants to infect"){
-      emp::Ptr<Organism> host = new Host(&random, &w, &config, int_val);
+      emp::Ptr<Organism> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(host, host_pos);
       REQUIRE(w.GetNumOrgs() == 2);
       REQUIRE(host->HasSym() == false);
 
       WHEN("the infection fails"){
         config.SYM_INFECTION_FAILURE_RATE(1);
-        emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
         w.AddOrgAt(sym, sym_pos);
         REQUIRE(w.GetNumOrgs() == 2);
         THEN("the sym is deleted"){
@@ -737,10 +734,11 @@ TEST_CASE( "ExtractSym", "[default]" ){
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
+    int world_size = 4;
+    w.Resize(world_size);
     size_t sym_index = 1;
     emp::WorldPosition sym_pos = emp::WorldPosition(0, sym_index);
-    emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+    emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
     w.AddOrgAt(sym, sym_pos);
     REQUIRE(w.GetSymPop()[sym_index] == sym);
@@ -750,6 +748,8 @@ TEST_CASE( "ExtractSym", "[default]" ){
     REQUIRE(sym == new_org);
     REQUIRE(w.GetNumOrgs() == 0);
     REQUIRE(w.GetSymPop()[sym_index] == nullptr);
+
+    sym.Delete();
   }
 }
 
@@ -759,10 +759,11 @@ TEST_CASE( "MoveIntoNewFreeWorldPos", "[default]" ){
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
+    int world_size = 4;
+    w.Resize(world_size);
 
-    emp::Ptr<Organism> parent_sym = new Symbiont(&random, &w, &config, int_val);
-    emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+    emp::Ptr<Organism> parent_sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+    emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
     size_t orig_pos = 3;
     emp::WorldPosition orig_sym_pos = emp::WorldPosition(0, orig_pos);
@@ -796,17 +797,20 @@ TEST_CASE( "Resize", "[default]" ){
     REQUIRE(pop_size == sym_pop_size);
     REQUIRE(pop_size == 0);
 
-    w.Resize(3,3);
+    size_t width = 3;
+    size_t height = 3;
+    w.Resize(width, height);
     pop_size = w.GetPop().size();
     sym_pop_size = w.GetSymPop().size();
     REQUIRE(pop_size == sym_pop_size);
-    REQUIRE(pop_size == 9);
+    REQUIRE(pop_size == (width * height));
 
-    w.Resize(11);
+    size_t world_size = 11;
+    w.Resize(world_size);
     pop_size = w.GetPop().size();
     sym_pop_size = w.GetSymPop().size();
     REQUIRE(pop_size == sym_pop_size);
-    REQUIRE(pop_size == 11);
+    REQUIRE(pop_size == world_size);
   }
 }
 
@@ -818,8 +822,9 @@ TEST_CASE( "AddOrgAt", "[default]" ){
     SymConfigBase config;
     int int_val = 0;
     SymWorld w(random);
-    w.Resize(2,2);
-    emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
+    int world_size = 4;
+    w.Resize(world_size);
+    emp::Ptr<Organism> sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
 
     WHEN("a sym is added into an empty spot"){
       THEN("it occupies that spot"){
@@ -832,7 +837,7 @@ TEST_CASE( "AddOrgAt", "[default]" ){
     }
     WHEN("a sym is added into an occupied spot"){
       THEN("it replaces the occupying sym"){
-        emp::Ptr<Organism> old_sym = new Symbiont(&random, &w, &config, int_val);
+        emp::Ptr<Organism> old_sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
         w.AddOrgAt(old_sym, 0);
         REQUIRE(w.GetNumOrgs() == 1);
         REQUIRE(w.GetSymPop()[0] == old_sym);
@@ -844,7 +849,6 @@ TEST_CASE( "AddOrgAt", "[default]" ){
     }
     WHEN("a sym is added to an out of bounds pos"){
       THEN("pop and sym_pop are expanded to fit it"){
-        emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_val);
         REQUIRE(w.GetSymPop().size() == 4);
         w.AddOrgAt(sym, emp::WorldPosition(0,7));
         REQUIRE(w.GetSymPop().size() == w.GetPop().size());
@@ -859,13 +863,14 @@ TEST_CASE( "GetSymAt", "[default]" ){
     emp::Random random(17);
     SymConfigBase config;
     int int_val = 0;
+    int world_size = 4;
     SymWorld w(random);
-    w.Resize(2,2);
+    w.Resize(world_size);
 
 
     WHEN("a request is made for an in-bounds sym"){
-      emp::Ptr<Organism> sym1 = new Symbiont(&random, &w, &config, int_val);
-      emp::Ptr<Organism> sym2 = new Symbiont(&random, &w, &config, int_val);
+      emp::Ptr<Organism> sym1 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+      emp::Ptr<Organism> sym2 = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
       w.AddOrgAt(sym1, 0);
       w.AddOrgAt(sym2, emp::WorldPosition(0,1));
       THEN("the sym at that position is returned"){
@@ -887,8 +892,9 @@ TEST_CASE( "DoSymDeath", "[default]" ){
     emp::Random random(17);
     SymConfigBase config;
     SymWorld w(random);
-    w.Resize(2,2);
-    emp::Ptr<Organism> s = new Symbiont(&random, &w, &config, 1);
+    int world_size = 4;
+    w.Resize(world_size);
+    emp::Ptr<Organism> s = emp::NewPtr<Symbiont>(&random, &w, &config, 1);
     size_t sym_position = 1;
     w.AddOrgAt(s, emp::WorldPosition(0, sym_position));
 
@@ -918,20 +924,22 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
   config.PHYLOGENY(1);
   int int_val = 0;
   SymWorld w(random);
-  w.Resize(2,2);
+  int world_size = 4;
+  w.Resize(world_size);
   w.SetTrackPhylogeny(1);
   w.SetNumPhyloBins(20);
 
 
-  emp::Ptr<Organism> host = new Host(&random, &w, &config, int_val);
+  emp::Ptr<Organism> host = emp::NewPtr<Host>(&random, &w, &config, int_val);
   emp::Ptr<emp::Systematics<Organism,int>> host_sys = w.GetHostSys();
 
   //ORGANISMS ADDED TO SYSTEMATICS
   WHEN("an organism is added to the world"){
     WHEN("the cell it's added to is occupied"){
       size_t pos = 0;
+      int_val = -1;
 
-      emp::Ptr<Organism> occupying_host = new Host(&random, &w, &config, -1);
+      emp::Ptr<Organism> occupying_host = emp::NewPtr<Host>(&random, &w, &config, int_val);
       w.AddOrgAt(occupying_host, pos);
       size_t expected_occupying_taxon_info = 0;
       size_t taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
@@ -950,6 +958,7 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
         REQUIRE(expected_taxon_info == taxon_info);
       }
     }
+
     WHEN("the cell it's added to is empty"){
       size_t pos = 0;
 
@@ -960,12 +969,13 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
       size_t taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       size_t expected_taxon_info = 10;
 
-      THEN("the occupying organism is removed from the systematic"){
+      THEN("the organism is tracked by the systematic"){
         REQUIRE(w.GetNumOrgs() == 1);
         REQUIRE(host_sys->GetNumActive() == 1);
         REQUIRE(expected_taxon_info == taxon_info);
       }
     }
+
 
     //ORGANISMS ADDED TO TAXA
     THEN("the organsim is added to the correct taxon"){
@@ -974,49 +984,49 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
       //taxon info 0
       double int_val = -1;
       int expected_taxon_info = 0;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       int taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 0
       int_val = -0.98;
       expected_taxon_info = 0;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 1
       int_val = -0.9;
       expected_taxon_info = 1;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 2
       int_val = -0.8;
       expected_taxon_info = 2;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 16
       int_val = 0.65 ;
       expected_taxon_info = 16;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 19
       int_val = 0.9;
       expected_taxon_info = 19;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 19
       int_val = 1;
       expected_taxon_info = 19;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
@@ -1025,33 +1035,36 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
       //taxon info 1
       int_val = 1;
       expected_taxon_info = 1;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 1
       int_val = 0;
       expected_taxon_info = 1;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
 
       //taxon info 1
       int_val = -0.001;
       expected_taxon_info = 0;
-      w.AddOrgAt(new Host(&random, &w, &config, int_val), pos);
+      w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_val), pos);
       taxon_info = host_sys->GetTaxonAt(pos)->GetInfo();
       REQUIRE(expected_taxon_info == taxon_info);
+
+      host.Delete();
     }
   }
 
   //ORGANISMS AND RELATIONSHIPS TRACKED
   WHEN("Several generations pass"){
     THEN("The phylogenetic relationships are tracked and accurate"){
-      w.Resize(10);
+      world_size = 10;
+      w.Resize(world_size);
       int num_descendants = 4;
       //add the first host
-      w.AddOrgAt(new Host(&random, &w, &config, 0), 0);
+      w.AddOrgAt(host, 0);
 
       //populate the world with descendents with various interaction values
       //Can't use num_descendants for the following array sizes because some
@@ -1060,7 +1073,7 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
       //bins: parent org in 10, then in int_vals order: 11, 9, 8, 11
       size_t parents[4] = {0, 1, 1, 3};
       for(int i = 0; i < num_descendants; i++){
-        w.AddOrgAt(new Host(&random, &w, &config, int_vals[i]), (i+1), parents[i]);
+        w.AddOrgAt(emp::NewPtr<Host>(&random, &w, &config, int_vals[i]), (i+1), parents[i]);
       }
 
       char lineages[][30] = {"Lineage:\n10\n",
@@ -1080,6 +1093,7 @@ TEST_CASE( "Host Phylogeny", "[default]" ){
   }
 }
 
+
 TEST_CASE( "Symbiont Phylogeny", "[default]" ){
   emp::Random random(17);
   SymConfigBase config;
@@ -1089,37 +1103,47 @@ TEST_CASE( "Symbiont Phylogeny", "[default]" ){
   config.PHYLOGENY(1);
   int int_val = 0;
   SymWorld w(random);
-  w.Resize(20);
+  int world_size = 20;
+  w.Resize(world_size);
   w.SetTrackPhylogeny(1);
   w.SetFreeLivingSyms(1);
   w.SetNumPhyloBins(20);
 
   emp::Ptr<emp::Systematics<Organism,int>> sym_sys = w.GetSymSys();
+
   WHEN("symbionts are added to the world"){
-    REQUIRE(sym_sys->GetNumActive() == 0);
-    size_t count = 8;
-    //Can't use count for the following array sizes because some
-    //compilers don't allow it
-    double int_vals[8] = {-1, -0.9, -0.82, 0, 0.5, 0.65, 0.9, 1};
-    int taxon_infos[8] = {0, 1, 1, 10, 15, 16, 19, 19};
-    //int taxon_infos[8] = {0, 0, 0, 2, 3, 4, 4, 4};
-    emp::Ptr<Organism> syms[count];
-    for(size_t i = 0; i < count; i++){
-      emp::Ptr<Organism> sym = new Symbiont(&random, &w, &config, int_vals[i]);
-      w.InjectSymbiont(sym);
-      REQUIRE(sym->GetTaxon()->GetInfo() == taxon_infos[i]);
+    THEN("they get added to the correct taxonomic bins"){
+      REQUIRE(sym_sys->GetNumActive() == 0);
+      size_t count = 8;
+      //Can't use count for the following array sizes because some
+      //compilers don't allow it
+      double int_vals[8] = {-1, -0.9, -0.82, 0, 0.5, 0.65, 0.9, 1};
+      int taxon_infos[8] = {0, 1, 1, 10, 15, 16, 19, 19};
+
+      emp::Ptr<Organism> syms[count];
+      emp::Ptr<Organism> sym;
+
+      for(size_t i = 0; i < count; i++){
+        sym = emp::NewPtr<Symbiont>(&random, &w, &config, int_vals[i]);
+        w.InjectSymbiont(sym);
+        REQUIRE(sym->GetTaxon()->GetInfo() == taxon_infos[i]);
+      }
     }
   }
+
   WHEN("symbionts are deleted"){
     THEN("they are no longer tracked by the sym systematic"){
+      world_size = 1;
+      w.Resize(world_size);
       REQUIRE(sym_sys->GetNumActive() == 0);
-      emp::Ptr<Organism> s1 = new Symbiont(&random, &w, &config, int_val);
-      w.InjectSymbiont(s1);
+      emp::Ptr<Organism> symbiont = emp::NewPtr<Symbiont>(&random, &w, &config, int_val);
+      w.InjectSymbiont(symbiont);
       REQUIRE(sym_sys->GetNumActive() == 1);
-      s1.Delete();
+      w.DoSymDeath(0);
       REQUIRE(sym_sys->GetNumActive() == 0);
     }
   }
+
   WHEN("generations pass"){
     config.MUTATION_SIZE(1);
     config.MUTATION_RATE(1);
@@ -1127,7 +1151,7 @@ TEST_CASE( "Symbiont Phylogeny", "[default]" ){
     size_t num_syms = 4;
 
     emp::Ptr<Organism> syms[num_syms];
-    syms[0] = new Symbiont(&random, &w, &config, 0);
+    syms[0] = emp::NewPtr<Symbiont>(&random, &w, &config, 0);
     w.AddSymToSystematic(syms[0]);
 
     for(size_t i = 1; i < num_syms; i++){
@@ -1146,12 +1170,15 @@ TEST_CASE( "Symbiont Phylogeny", "[default]" ){
         sym_sys->PrintLineage(syms[i]->GetTaxon(), result);
         REQUIRE(result.str() == lineages[i]);
       }
+      syms[0].Delete();
+      syms[1].Delete();
     }
+
     THEN("Their birth and destruction dates are tracked"){
       //all curr syms should have orig times of 0
-      for(size_t i = 0; i < num_syms; i++) REQUIRE(syms[i]->GetTaxon()->GetOriginationTime() == 0);
-
-
+      for(size_t i = 0; i < num_syms; i++){
+        REQUIRE(syms[i]->GetTaxon()->GetOriginationTime() == 0);
+      }
       w.Update();
 
       //after update, times should now be 1
@@ -1159,14 +1186,14 @@ TEST_CASE( "Symbiont Phylogeny", "[default]" ){
       syms[0].Delete();
       REQUIRE(dest_tax->GetDestructionTime() == 1);
 
-      syms[0] = syms[1]->reproduce();
-      REQUIRE(syms[0]->GetTaxon()->GetOriginationTime() == 1);
-
       //another update, times 2
       w.Update();
-      dest_tax = syms[0]->GetTaxon();
-      syms[0].Delete();
+      dest_tax = syms[1]->GetTaxon();
+      syms[1].Delete();
       REQUIRE(dest_tax->GetDestructionTime() == 2);
     }
+
+    syms[2].Delete();
+    syms[3].Delete();
   }
 }

--- a/source/test/default_mode_test/Symbiont.test.cc
+++ b/source/test/default_mode_test/Symbiont.test.cc
@@ -273,7 +273,7 @@ TEST_CASE("mutate", "[default]") {
             config.FREE_LIVING_SYMS(1);
             config.SYM_INFECTION_CHANCE(orig_infection_chance);
             emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
-            sym->mutate();
+            sym->Mutate();
 
             THEN("Mutation occurs and both interaction value and infection chance change"){
                 REQUIRE(sym->GetIntVal() != int_val);
@@ -289,7 +289,7 @@ TEST_CASE("mutate", "[default]") {
 
         WHEN("free living symbionts are not allowed"){
             emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
-            sym->mutate();
+            sym->Mutate();
 
             THEN("Mutation occurs and only interaction value changes") {
                 REQUIRE(sym->GetIntVal() != int_val);
@@ -312,7 +312,7 @@ TEST_CASE("mutate", "[default]") {
         config.MUTATION_SIZE(0);
         emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
-        sym->mutate();
+        sym->Mutate();
 
 
         THEN("Mutation does not occur and interaction value does not change") {
@@ -345,7 +345,7 @@ TEST_CASE("reproduce", "[default]") {
         emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
         sym->SetAge(10);
 
-        emp::Ptr<Organism> sym_baby = sym->reproduce();
+        emp::Ptr<Organism> sym_baby = sym->Reproduce();
 
 
         THEN("Offspring's interaction value equals parent's interaction value") {
@@ -390,7 +390,7 @@ TEST_CASE("reproduce", "[default]") {
         config.SYM_INFECTION_CHANCE(inf_chance);
         emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
-        emp::Ptr<Organism> sym_baby = sym2->reproduce();
+        emp::Ptr<Organism> sym_baby = sym2->Reproduce();
 
 
         THEN("Offspring's interaction value does not equal parent's interaction value") {
@@ -678,14 +678,14 @@ TEST_CASE("Symbiont GrowOlder", "[default]"){
     }
 }
 
-TEST_CASE("Symbiont makeNew", "[default]"){
+TEST_CASE("Symbiont MakeNew", "[default]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     SymWorld w(*random);
     SymConfigBase config;
 
     double sym_int_val = 0.2;
     emp::Ptr<Organism> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
-    emp::Ptr<Organism> sym2 = sym1->makeNew();
+    emp::Ptr<Organism> sym2 = sym1->MakeNew();
 
     THEN("The new symbiont has the same genome as its parent, but age and points 0"){
         REQUIRE(sym2->GetIntVal() == sym1->GetIntVal());

--- a/source/test/default_mode_test/Symbiont.test.cc
+++ b/source/test/default_mode_test/Symbiont.test.cc
@@ -9,29 +9,33 @@ TEST_CASE("Symbiont Constructor", "[default]") {
     SymWorld * world = &w;
 
     double int_val = -2;
-    REQUIRE_THROWS(new Symbiont(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<Symbiont>(random, world, &config, int_val) );
 
     int_val = -1;
-    Symbiont * s1 = new Symbiont(random, world, &config, int_val);
-    CHECK(s1->GetIntVal() == int_val);
-    CHECK(s1->GetAge() == 0); 
-    CHECK(s1->GetPoints() == 0);
+    emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+    CHECK(sym1->GetIntVal() == int_val);
+    CHECK(sym1->GetAge() == 0);
+    CHECK(sym1->GetPoints() == 0);
 
     int_val = -1;
     double points = 10;
-    Symbiont * s2 = new Symbiont(random, world, &config, int_val, points);
-    CHECK(s2->GetIntVal() == int_val);
-    CHECK(s2->GetAge() == 0);
-    CHECK(s2->GetPoints() == points);
+    emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
+    CHECK(sym2->GetIntVal() == int_val);
+    CHECK(sym2->GetAge() == 0);
+    CHECK(sym2->GetPoints() == points);
 
     int_val = 1;
-    Symbiont * s3 = new Symbiont(random, world, &config, int_val);
-    CHECK(s3->GetIntVal() == int_val);
-    CHECK(s3->GetAge() == 0);
-    CHECK(s3->GetPoints() == 0);
+    emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+    CHECK(sym3->GetIntVal() == int_val);
+    CHECK(sym3->GetAge() == 0);
+    CHECK(sym3->GetPoints() == 0);
 
     int_val = 2;
-    REQUIRE_THROWS(new Symbiont(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<Symbiont>(random, world, &config, int_val) );
+
+    sym1.Delete();
+    sym2.Delete();
+    sym3.Delete();
 }
 
 TEST_CASE("SetIntVal, GetIntVal", "[default]") {
@@ -42,35 +46,39 @@ TEST_CASE("SetIntVal, GetIntVal", "[default]") {
     SymWorld * world = &w;
 
     double int_val = -1;
-    Symbiont * s = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     int_val = -2;
-    REQUIRE_THROWS( s->SetIntVal(int_val) );
+    REQUIRE_THROWS( sym1->SetIntVal(int_val) );
 
     int_val = -1;
-    Symbiont * s2 = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     int_val = 1;
-    s2->SetIntVal(int_val);
+    sym2->SetIntVal(int_val);
     double orig_int_val = 1;
 
-    REQUIRE(s2->GetIntVal() == orig_int_val);
+    REQUIRE(sym2->GetIntVal() == orig_int_val);
 
     int_val = -1;
-    Symbiont * s3 = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym3 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     int_val = 2;
-    REQUIRE_THROWS( s3->SetIntVal(int_val) ) ;
+    REQUIRE_THROWS( sym3->SetIntVal(int_val) ) ;
 
     int_val = 0;
-    Symbiont * s4 = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym4 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     int_val = -1;
-    s4->SetIntVal(int_val);
+    sym4->SetIntVal(int_val);
     orig_int_val = -1;
 
-    REQUIRE( s4->GetIntVal() == orig_int_val) ;
+    REQUIRE( sym4->GetIntVal() == orig_int_val) ;
 
+    sym1.Delete();
+    sym2.Delete();
+    sym3.Delete();
+    sym4.Delete();
 }
 
 TEST_CASE("SetInfectionChance, GetInfectionChance", "[default]") {
@@ -81,7 +89,7 @@ TEST_CASE("SetInfectionChance, GetInfectionChance", "[default]") {
     SymWorld * world = &w;
 
     double int_val = -1;
-    Symbiont * sym = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     double infection_chance = -1;
     REQUIRE_THROWS( sym->SetInfectionChance(infection_chance));
@@ -96,6 +104,8 @@ TEST_CASE("SetInfectionChance, GetInfectionChance", "[default]") {
 
     infection_chance = 2;
     REQUIRE_THROWS(sym->SetInfectionChance(infection_chance));
+
+    sym.Delete();
 }
 
 TEST_CASE("SetPoints, GetPoints", "[default]") {
@@ -106,25 +116,27 @@ TEST_CASE("SetPoints, GetPoints", "[default]") {
     SymWorld * world = &w;
 
     double int_val = -1;
-    Symbiont * s = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     int points = 1;
-    s->SetPoints(points);
+    sym->SetPoints(points);
     double orig_points = 1;
 
-    REQUIRE( s->GetPoints() == orig_points);
+    REQUIRE( sym->GetPoints() == orig_points);
 
     int add_points = -1;
-    s->AddPoints(add_points);
+    sym->AddPoints(add_points);
     orig_points = 0;
 
-    REQUIRE( s->GetPoints() == orig_points);
+    REQUIRE( sym->GetPoints() == orig_points);
 
     add_points = 150;
-    s->AddPoints(add_points);
+    sym->AddPoints(add_points);
     orig_points = 150;
 
-    REQUIRE(s->GetPoints() == orig_points);
+    REQUIRE(sym->GetPoints() == orig_points);
+
+    sym.Delete();
 }
 
 TEST_CASE("Symbiont SetDead, GetDead", "[default]"){
@@ -134,16 +146,18 @@ TEST_CASE("Symbiont SetDead, GetDead", "[default]"){
     SymWorld * world = &w;
 
     double int_val = -1;
-    Symbiont * s = new Symbiont(random, world, &config, int_val);
+    emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
     //new symbionts are alive until specified otherwise
     bool expected_dead = false;
-    REQUIRE(s->GetDead() == expected_dead);
+    REQUIRE(sym->GetDead() == expected_dead);
 
     //verify that setting it to dead means that death is set to true
     expected_dead = true;
-    s->SetDead();
-    REQUIRE(s->GetDead() == expected_dead);
+    sym->SetDead();
+    REQUIRE(sym->GetDead() == expected_dead);
+
+    sym.Delete();
 }
 
 TEST_CASE("WantsToInfect", "[default]"){
@@ -155,24 +169,30 @@ TEST_CASE("WantsToInfect", "[default]"){
 
     WHEN("sym infection chance is 0"){
         config.SYM_INFECTION_CHANCE(0);
-        Symbiont * sym1 = new Symbiont(random, world, &config, int_val);
-        Symbiont * sym2 = new Symbiont(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
         THEN("syms never want to infect"){
             REQUIRE(sym1->WantsToInfect() == false);
             REQUIRE(sym2->WantsToInfect() == false);
         }
+
+        sym1.Delete();
+        sym2.Delete();
     }
 
     WHEN("sym infection chance is 1"){
         config.SYM_INFECTION_CHANCE(1);
-        Symbiont * sym1 = new Symbiont(random, world, &config, int_val);
-        Symbiont * sym2 = new Symbiont(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
         THEN("syms always want to infect"){
             REQUIRE(sym1->WantsToInfect() == true);
             REQUIRE(sym2->WantsToInfect() == true);
         }
+
+        sym1.Delete();
+        sym2.Delete();
     }
 }
 
@@ -185,44 +205,55 @@ TEST_CASE("InfectionFails", "[default]"){
 
     WHEN("sym infection failure rate is 0"){
         config.SYM_INFECTION_FAILURE_RATE(0);
-        Symbiont * sym1 = new Symbiont(random, world, &config, int_val);
-        Symbiont * sym2 = new Symbiont(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
         THEN("infection never fails"){
             REQUIRE(sym1->InfectionFails() == false);
             REQUIRE(sym2->InfectionFails() == false);
         }
+
+        sym1.Delete();
+        sym2.Delete();
     }
 
     WHEN("sym infection failure rate is between 0 and 1"){
         config.SYM_INFECTION_FAILURE_RATE(0.5);
-        emp::Ptr<Organism> s1 = new Symbiont(random, world, &config, int_val);
-        emp::Ptr<Organism> s2 = new Symbiont(random, world, &config, int_val);
-        emp::Ptr<Organism> s3 = new Symbiont(random, world, &config, int_val);
-        emp::Ptr<Organism> s4 = new Symbiont(random, world, &config, int_val);
+        emp::Ptr<Organism> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Organism> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Organism> sym3 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Organism> sym4 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
         size_t failed_infection_count = 0;
         size_t total_possible = 4;
 
-        if(s1->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
-        if(s2->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
-        if(s3->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
-        if(s4->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
+        if(sym1->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
+        if(sym2->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
+        if(sym3->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
+        if(sym4->InfectionFails() == true) failed_infection_count = failed_infection_count + 1;
 
         THEN("infection sometimes fails, sometimes doesn't"){
             REQUIRE(failed_infection_count < total_possible);
             REQUIRE(failed_infection_count > 0);
         }
+
+        sym1.Delete();
+        sym2.Delete();
+        sym3.Delete();
+        sym4.Delete();
     }
 
     WHEN("sym infection failure rate is 1"){
         config.SYM_INFECTION_FAILURE_RATE(1);
-        Symbiont * sym1 = new Symbiont(random, world, &config, int_val);
-        Symbiont * sym2 = new Symbiont(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym1 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val);
 
         THEN("infection always fails"){
             REQUIRE(sym1->InfectionFails() == true);
             REQUIRE(sym2->InfectionFails() == true);
         }
+
+        sym1.Delete();
+        sym2.Delete();
     }
 }
 
@@ -241,28 +272,32 @@ TEST_CASE("mutate", "[default]") {
         WHEN("free living symbionts are allowed"){
             config.FREE_LIVING_SYMS(1);
             config.SYM_INFECTION_CHANCE(orig_infection_chance);
-            Symbiont * s = new Symbiont(random, world, &config, int_val);
-            s->mutate();
+            emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+            sym->mutate();
 
             THEN("Mutation occurs and both interaction value and infection chance change"){
-                REQUIRE(s->GetIntVal() != int_val);
-                REQUIRE(s->GetIntVal() <= 1);
-                REQUIRE(s->GetIntVal() >= -1);
-                REQUIRE(s->GetInfectionChance() != orig_infection_chance);
-                REQUIRE(s->GetInfectionChance() >= 0);
-                REQUIRE(s->GetInfectionChance() <= 1);
+                REQUIRE(sym->GetIntVal() != int_val);
+                REQUIRE(sym->GetIntVal() <= 1);
+                REQUIRE(sym->GetIntVal() >= -1);
+                REQUIRE(sym->GetInfectionChance() != orig_infection_chance);
+                REQUIRE(sym->GetInfectionChance() >= 0);
+                REQUIRE(sym->GetInfectionChance() <= 1);
             }
+
+            sym.Delete();
         }
 
         WHEN("free living symbionts are not allowed"){
-            Symbiont * s = new Symbiont(random, world, &config, int_val);
-            s->mutate();
+            emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val);
+            sym->mutate();
 
             THEN("Mutation occurs and only interaction value changes") {
-                REQUIRE(s->GetIntVal() != int_val);
-                REQUIRE(s->GetIntVal() <= 1);
-                REQUIRE(s->GetIntVal() >= -1);
+                REQUIRE(sym->GetIntVal() != int_val);
+                REQUIRE(sym->GetIntVal() <= 1);
+                REQUIRE(sym->GetIntVal() >= -1);
             }
+
+            sym.Delete();
         }
     }
 
@@ -275,14 +310,16 @@ TEST_CASE("mutate", "[default]") {
         config.HORIZ_TRANS(true);
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
-        Symbiont * s = new Symbiont(random, world, &config, int_val, points);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
-        s->mutate();
+        sym->mutate();
 
 
         THEN("Mutation does not occur and interaction value does not change") {
-            REQUIRE(s->GetIntVal() == orig_int_val);
+            REQUIRE(sym->GetIntVal() == orig_int_val);
         }
+
+        sym.Delete();
     }
 }
 
@@ -305,24 +342,24 @@ TEST_CASE("reproduce", "[default]") {
         config.MUTATION_SIZE(0);
         config.FREE_LIVING_SYMS(1);
         config.SYM_INFECTION_CHANCE(inf_chance);
-        Symbiont * s = new Symbiont(random, world, &config, int_val, points);
-        s->SetAge(10);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
+        sym->SetAge(10);
 
-        emp::Ptr<Organism> sym_baby = s->reproduce();
+        emp::Ptr<Organism> sym_baby = sym->reproduce();
 
 
         THEN("Offspring's interaction value equals parent's interaction value") {
             double sym_baby_int_val = 0;
             REQUIRE( sym_baby->GetIntVal() == sym_baby_int_val);
             REQUIRE( sym_baby->GetIntVal() == parent_orig_int_val);
-            REQUIRE( s->GetIntVal() == parent_orig_int_val);
+            REQUIRE( sym->GetIntVal() == parent_orig_int_val);
         }
 
         THEN("Offspring's infection chance equals parent's infection chance") {
             double sym_baby_inf_chance = 0.5;
             REQUIRE( sym_baby->GetInfectionChance() == sym_baby_inf_chance);
             REQUIRE( sym_baby->GetInfectionChance() == parent_orig_inf_chance);
-            REQUIRE( s->GetInfectionChance() == parent_orig_inf_chance);
+            REQUIRE( sym->GetInfectionChance() == parent_orig_inf_chance);
         }
 
         THEN("Offspring's points are zero") {
@@ -335,6 +372,7 @@ TEST_CASE("reproduce", "[default]") {
             REQUIRE(sym_baby->GetAge() == 0);
         }
 
+        sym.Delete();
         sym_baby.Delete();
     }
 
@@ -350,23 +388,23 @@ TEST_CASE("reproduce", "[default]") {
         config.MUTATION_SIZE(0.01);
         config.FREE_LIVING_SYMS(1);
         config.SYM_INFECTION_CHANCE(inf_chance);
-        Symbiont * s2 = new Symbiont(random, world, &config, int_val, points);
+        emp::Ptr<Symbiont> sym2 = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
-        emp::Ptr<Organism> sym_baby = s2->reproduce();
+        emp::Ptr<Organism> sym_baby = sym2->reproduce();
 
 
         THEN("Offspring's interaction value does not equal parent's interaction value") {
             REQUIRE(sym_baby->GetIntVal() != parent_orig_int_val);
             REQUIRE(sym_baby->GetIntVal() <= 1);
             REQUIRE(sym_baby->GetIntVal() >= -1);
-            REQUIRE(s2->GetIntVal() == parent_orig_int_val);
+            REQUIRE(sym2->GetIntVal() == parent_orig_int_val);
         }
 
         THEN("Offspring's infection chance does not equal parent's infection chance") {
             REQUIRE( sym_baby->GetInfectionChance() != parent_orig_inf_chance);
             REQUIRE( sym_baby->GetInfectionChance() <= 1);
             REQUIRE( sym_baby->GetInfectionChance() >= -1);
-            REQUIRE( s2->GetInfectionChance() == parent_orig_inf_chance);
+            REQUIRE( sym2->GetInfectionChance() == parent_orig_inf_chance);
         }
 
         THEN("Offspring's points are zero") {
@@ -379,6 +417,7 @@ TEST_CASE("reproduce", "[default]") {
             REQUIRE(sym_baby->GetAge() == 0);
         }
 
+        sym2.Delete();
         sym_baby.Delete();
     }
 
@@ -399,19 +438,21 @@ TEST_CASE("Process", "[default]") {
         config.SYM_HORIZ_TRANS_RES(140.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0);
-        Symbiont * s = new Symbiont(random, world, &config, int_val, points);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
         int add_points = 200;
-        s->AddPoints(add_points);
+        sym->AddPoints(add_points);
 
         int location = 10;
-        s->Process(location);
+        sym->Process(location);
 
 
         THEN("Points changes and is set to 0") {
             int points_post_reproduction = 0;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(sym->GetPoints() == points_post_reproduction);
         }
+
+        sym.Delete();
     }
 
 
@@ -422,19 +463,21 @@ TEST_CASE("Process", "[default]") {
         config.SYM_HORIZ_TRANS_RES(200.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0.0);
-        Symbiont * s = new Symbiont(random, world, &config, int_val, points);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
         int add_points = 50;
-        s->AddPoints(add_points);
+        sym->AddPoints(add_points);
 
         int location = 10;
-        s->Process(location);
+        sym->Process(location);
 
 
         THEN("Points does not change") {
             int points_post_reproduction = 50;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(sym->GetPoints() == points_post_reproduction);
         }
+
+        sym.Delete();
     }
 
 
@@ -445,16 +488,18 @@ TEST_CASE("Process", "[default]") {
         config.SYM_HORIZ_TRANS_RES(80.0);
         config.HORIZ_TRANS(false);
         config.MUTATION_SIZE(0.0);
-        Symbiont * s = new Symbiont(random, world, &config, int_val, points);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
         int location = 10;
-        s->Process(location);
+        sym->Process(location);
 
 
         THEN("Points does not change") {
             int points_post_reproduction = 100;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(sym->GetPoints() == points_post_reproduction);
         }
+
+        sym.Delete();
     }
 
     WHEN("Horizontal transmission is false and points and points is less then sym_h_res") {
@@ -464,18 +509,19 @@ TEST_CASE("Process", "[default]") {
         config.SYM_HORIZ_TRANS_RES(80.0);
         config.HORIZ_TRANS(false);
         config.MUTATION_SIZE(0.0);
-        Symbiont * s = new Symbiont(random, world, &config, int_val, points);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, int_val, points);
 
         int location = 10;
-        s->Process(location);
+        sym->Process(location);
 
 
         THEN("Points does not change") {
             int points_post_reproduction = 40;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(sym->GetPoints() == points_post_reproduction);
         }
-    }
 
+        sym.Delete();
+    }
 }
 
 TEST_CASE("Symbiont ProcessResources", "[default]"){
@@ -491,9 +537,9 @@ TEST_CASE("Symbiont ProcessResources", "[default]"){
 
         WHEN("host_int_val > 0"){
             double host_int_val = 0.2;
-            Host * h = new Host(random, &w, &config, host_int_val);
-            Symbiont * s = new Symbiont(random, world, &config, sym_int_val);
-            h->AddSymbiont(s);
+            emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+            emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, sym_int_val);
+            host->AddSymbiont(sym);
 
             // double resources = 100;
             // double hostDonation = 20;
@@ -501,22 +547,24 @@ TEST_CASE("Symbiont ProcessResources", "[default]"){
             double expected_sym_points = 68; // hostDonation + stolen
             double expected_return = 0; // hostportion * synergy
 
-            h->SetResInProcess(80);
+            host->SetResInProcess(80);
 
             THEN("sym receives a donation and stolen resources, host receives betrayal"){
-                REQUIRE(s->ProcessResources(20) == expected_return);
-                REQUIRE(s->GetPoints() == expected_sym_points);
+                REQUIRE(sym->ProcessResources(20) == expected_return);
+                REQUIRE(sym->GetPoints() == expected_sym_points);
 
             }
+
+            host.Delete();
         }
 
         WHEN("host_int_val < 0 and resources are placed into defense"){
 
             WHEN("host successfully defends from symsteal"){
                 double host_int_val = -0.8;
-                Host * h = new Host(random, &w, &config, host_int_val);
-                Symbiont * s = new Symbiont(random, world, &config, sym_int_val);
-                h->AddSymbiont(s);
+                emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+                emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, sym_int_val);
+                host->AddSymbiont(sym);
 
                 // double resources = 100;
                 // double hostDonation = 0;
@@ -525,18 +573,20 @@ TEST_CASE("Symbiont ProcessResources", "[default]"){
                 double expected_sym_points = 0; // hostDonation + stolen
                 double expected_return = 0; // hostportion * synergy
 
-                h->SetResInProcess(20);
+                host->SetResInProcess(20);
                 THEN("symbiont is unsuccessful at stealing"){
-                    REQUIRE(s->ProcessResources(0) == expected_return);
-                    REQUIRE(s->GetPoints() == expected_sym_points);
+                    REQUIRE(sym->ProcessResources(0) == expected_return);
+                    REQUIRE(sym->GetPoints() == expected_sym_points);
                 }
+
+                host.Delete();
             }
 
             WHEN("host fails at defense"){
                 double host_int_val = -0.5;
-                Host * h = new Host(random, &w, &config, host_int_val);
-                Symbiont * s = new Symbiont(random, world, &config, sym_int_val);
-                h->AddSymbiont(s);
+                emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+                emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, sym_int_val);
+                host->AddSymbiont(sym);
 
                 // double resources = 100;
                 // double hostDonation = 0;
@@ -545,12 +595,14 @@ TEST_CASE("Symbiont ProcessResources", "[default]"){
                 double expected_sym_points = 5; // hostDonation + stolen
                 double expected_return = 0; // hostportion * synergy
 
-                h->SetResInProcess(50);
+                host->SetResInProcess(50);
 
                 THEN("Sym steals successfully"){
-                    REQUIRE(s->ProcessResources(0) == expected_return);
-                    REQUIRE(s->GetPoints() == Approx(expected_sym_points));
+                    REQUIRE(sym->ProcessResources(0) == expected_return);
+                    REQUIRE(sym->GetPoints() == Approx(expected_sym_points));
                 }
+
+                host.Delete();
             }
 
         }
@@ -560,9 +612,9 @@ TEST_CASE("Symbiont ProcessResources", "[default]"){
     WHEN("sym_int_val > 0") {
         double sym_int_val = 0.2;
         double host_int_val = 0.5;
-        Host * h = new Host(random, &w, &config, host_int_val);
-        Symbiont * s = new Symbiont(random, world, &config, sym_int_val);
-        h->AddSymbiont(s);
+        emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, host_int_val);
+        emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, world, &config, sym_int_val);
+        host->AddSymbiont(sym);
 
         // double resources = 100;
         // double hostDonation = 50;
@@ -570,13 +622,15 @@ TEST_CASE("Symbiont ProcessResources", "[default]"){
         double expected_sym_points = 40; // hostDonation - hostPortion
         double expected_return = 50; // hostPortion * synergy
 
-        h->SetResInProcess(50);
+        host->SetResInProcess(50);
 
 
         THEN("Sym attempts to give benefit back"){
-            REQUIRE(s->ProcessResources(50) == expected_return);
-            REQUIRE(s->GetPoints() == expected_sym_points);
+            REQUIRE(sym->ProcessResources(50) == expected_return);
+            REQUIRE(sym->GetPoints() == expected_sym_points);
         }
+
+        host.Delete();
     }
 
 }
@@ -590,36 +644,36 @@ TEST_CASE("Symbiont GrowOlder", "[default]"){
 
     WHEN ("A free-living symbiont reaches its maximum age"){
       config.FREE_LIVING_SYMS(1);
-      Symbiont * s = new Symbiont(random, &w, &config, 1);
-      w.AddOrgAt(s, 1);
+      emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, &w, &config, 1);
+      w.AddOrgAt(sym, emp::WorldPosition(0,1));
       THEN("The symbiont dies and gets removed from the world"){
         REQUIRE(w.GetNumOrgs() == 1);
-        REQUIRE(s->GetDead() == false);
-        REQUIRE(s->GetAge() == 0);
+        REQUIRE(sym->GetDead() == false);
+        REQUIRE(sym->GetAge() == 0);
         w.Update(); //sym goes from age 1->2
-        REQUIRE(s->GetAge() == 1);
+        REQUIRE(sym->GetAge() == 1);
         w.Update();
-        REQUIRE(s->GetAge() == 2);
+        REQUIRE(sym->GetAge() == 2);
         w.Update(); //sym goes from age 2->3, gets set to dead
         w.Update(); //sym is deleted (before it can process)
         REQUIRE(w.GetNumOrgs() == 0);
       }
     }
     WHEN ("A hosted symbiont reaches its maximum age"){
-      Symbiont * s = new Symbiont(random, &w, &config, 1);
-      Host * h = new Host(random, &w, &config, 1);
-      w.AddOrgAt(h, 1);
-      h->AddSymbiont(s);
+      emp::Ptr<Symbiont> sym = emp::NewPtr<Symbiont>(random, &w, &config, 1);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, 1);
+      w.AddOrgAt(host, 1);
+      host->AddSymbiont(sym);
       THEN("It dies and gets removed from its host"){
-        REQUIRE(h->HasSym() == true);
-        REQUIRE(s->GetAge() == 0);
-        h->Process(1);
-        REQUIRE(s->GetAge() == 1);
-        h->Process(1);
-        REQUIRE(h->HasSym() == true);
-        REQUIRE(s->GetAge() == 2);
-        h->Process(1); //should now be dead and removed
-        REQUIRE(h->HasSym() == false);
+        REQUIRE(host->HasSym() == true);
+        REQUIRE(sym->GetAge() == 0);
+        host->Process(1);
+        REQUIRE(sym->GetAge() == 1);
+        host->Process(1);
+        REQUIRE(host->HasSym() == true);
+        REQUIRE(sym->GetAge() == 2);
+        host->Process(1); //should now be dead and removed
+        REQUIRE(host->HasSym() == false);
       }
     }
 }
@@ -630,15 +684,18 @@ TEST_CASE("Symbiont makeNew", "[default]"){
     SymConfigBase config;
 
     double sym_int_val = 0.2;
-    Organism * s1 = new Symbiont(random, &w, &config, sym_int_val);
-    Organism * s2 = s1->makeNew();
+    emp::Ptr<Organism> sym1 = emp::NewPtr<Symbiont>(random, &w, &config, sym_int_val);
+    emp::Ptr<Organism> sym2 = sym1->makeNew();
 
     THEN("The new symbiont has the same genome as its parent, but age and points 0"){
-        REQUIRE(s2->GetIntVal() == s1->GetIntVal());
-        REQUIRE(s2->GetInfectionChance() == s1->GetInfectionChance());
-        REQUIRE(s2->GetAge() == 0);
-        REQUIRE(s2->GetPoints() == 0);
+        REQUIRE(sym2->GetIntVal() == sym1->GetIntVal());
+        REQUIRE(sym2->GetInfectionChance() == sym1->GetInfectionChance());
+        REQUIRE(sym2->GetAge() == 0);
+        REQUIRE(sym2->GetPoints() == 0);
         //check that the offspring is the correct class
-        REQUIRE(typeid(*s2).name() == typeid(*s1).name());
+        REQUIRE(typeid(*sym2).name() == typeid(*sym1).name());
     }
+
+    sym1.Delete();
+    sym2.Delete();
 }

--- a/source/test/efficient_mode_test/EfficientDataNodes.test.cc
+++ b/source/test/efficient_mode_test/EfficientDataNodes.test.cc
@@ -23,12 +23,12 @@ TEST_CASE("GetEfficiencyDataNode", "[efficient]"){
 
       double expected_av = 0.54;
 
-      Host *host = new EfficientHost(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<EfficientHost>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
 
       for(size_t i = 0; i < (num_syms/2); i++){
-        w.AddOrgAt(new EfficientSymbiont(&random, &w, &config, int_val, points, free_sym_efficiencies[i]), emp::WorldPosition(0, i));
-        host->AddSymbiont(new EfficientSymbiont(&random, &w, &config, int_val, points, hosted_sym_efficiencies[i]));
+        w.AddOrgAt(emp::NewPtr<EfficientSymbiont>(&random, &w, &config, int_val, points, free_sym_efficiencies[i]), emp::WorldPosition(0, i));
+        host->AddSymbiont(emp::NewPtr<EfficientSymbiont>(&random, &w, &config, int_val, points, hosted_sym_efficiencies[i]));
       }
 
       w.Update();

--- a/source/test/efficient_mode_test/EfficientHost.test.cc
+++ b/source/test/efficient_mode_test/EfficientHost.test.cc
@@ -13,7 +13,7 @@ TEST_CASE("EfficientHost Constructor", "[efficient]"){
     int_val = -1;
     EfficientHost * h1 = new EfficientHost(random, world, &config, int_val);
     CHECK(h1->GetIntVal() == int_val);
-    CHECK(h1->GetAge() == 0); 
+    CHECK(h1->GetAge() == 0);
     CHECK(h1->GetPoints() == 0);
 
     int_val = -1;
@@ -38,7 +38,7 @@ TEST_CASE("EfficientHost Constructor", "[efficient]"){
     REQUIRE_THROWS(new EfficientHost(random, world, &config, int_val) );
 }
 
-TEST_CASE("EfficientHost makeNew", "[efficient]"){
+TEST_CASE("EfficientHost MakeNew", "[efficient]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     EfficientWorld w(*random);
     SymConfigBase config;
@@ -47,7 +47,7 @@ TEST_CASE("EfficientHost makeNew", "[efficient]"){
     double parent_efficiency = 0.5;
     Organism * h1 = new EfficientHost(random, &w, &config, parent_int_val);
     h1->SetEfficiency(parent_efficiency);
-    Organism * h2 = h1->makeNew();
+    Organism * h2 = h1->MakeNew();
 
     THEN("The new host has properties of the original host, and has 0 points and 0 age"){
         REQUIRE(h2->GetIntVal() == h1->GetIntVal());

--- a/source/test/efficient_mode_test/EfficientHost.test.cc
+++ b/source/test/efficient_mode_test/EfficientHost.test.cc
@@ -8,13 +8,13 @@ TEST_CASE("EfficientHost Constructor", "[efficient]"){
     EfficientWorld * world = &w;
 
     double int_val = -2;
-    REQUIRE_THROWS( new EfficientHost(random, world, &config, int_val) );
+    REQUIRE_THROWS( emp::NewPtr<EfficientHost>(random, world, &config, int_val) );
 
     int_val = -1;
-    EfficientHost * h1 = new EfficientHost(random, world, &config, int_val);
-    CHECK(h1->GetIntVal() == int_val);
-    CHECK(h1->GetAge() == 0);
-    CHECK(h1->GetPoints() == 0);
+    emp::Ptr<EfficientHost> host1 = emp::NewPtr<EfficientHost>(random, world, &config, int_val);
+    CHECK(host1->GetIntVal() == int_val);
+    CHECK(host1->GetAge() == 0);
+    CHECK(host1->GetPoints() == 0);
 
     int_val = -1;
     emp::vector<emp::Ptr<Organism>> syms = {};
@@ -22,20 +22,24 @@ TEST_CASE("EfficientHost Constructor", "[efficient]"){
     std::set<int> set = std::set<int>();
     double points = 10;
     double efficiency = 0.5;
-    EfficientHost * h2 = new EfficientHost(random, world, &config, int_val, syms, repro_syms, set, points, efficiency);
-    CHECK(h2->GetIntVal() == int_val);
-    CHECK(h2->GetEfficiency() == efficiency);
-    CHECK(h2->GetAge() == 0);
-    CHECK(h2->GetPoints() == points);
+    emp::Ptr<EfficientHost> host2 = emp::NewPtr<EfficientHost>(random, world, &config, int_val, syms, repro_syms, set, points, efficiency);
+    CHECK(host2->GetIntVal() == int_val);
+    CHECK(host2->GetEfficiency() == efficiency);
+    CHECK(host2->GetAge() == 0);
+    CHECK(host2->GetPoints() == points);
 
     int_val = 1;
-    EfficientHost * h3 = new EfficientHost(random, world, &config, int_val);
-    CHECK(h3->GetIntVal() == int_val);
-    CHECK(h3->GetAge() == 0);
-    CHECK(h3->GetPoints() == 0);
+    emp::Ptr<EfficientHost> host3 = emp::NewPtr<EfficientHost>(random, world, &config, int_val);
+    CHECK(host3->GetIntVal() == int_val);
+    CHECK(host3->GetAge() == 0);
+    CHECK(host3->GetPoints() == 0);
 
     int_val = 2;
-    REQUIRE_THROWS(new EfficientHost(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<EfficientHost>(random, world, &config, int_val) );
+
+    host1.Delete();
+    host2.Delete();
+    host3.Delete();
 }
 
 TEST_CASE("EfficientHost MakeNew", "[efficient]"){
@@ -45,18 +49,20 @@ TEST_CASE("EfficientHost MakeNew", "[efficient]"){
 
     double parent_int_val = 0.2;
     double parent_efficiency = 0.5;
-    Organism * h1 = new EfficientHost(random, &w, &config, parent_int_val);
-    h1->SetEfficiency(parent_efficiency);
-    Organism * h2 = h1->MakeNew();
+    emp::Ptr<Organism> host1 = emp::NewPtr<EfficientHost>(random, &w, &config, parent_int_val);
+    host1->SetEfficiency(parent_efficiency);
+    emp::Ptr<Organism> host2 = host1->MakeNew();
 
     THEN("The new host has properties of the original host, and has 0 points and 0 age"){
-        REQUIRE(h2->GetIntVal() == h1->GetIntVal());
-        REQUIRE(h2->GetEfficiency() == h1->GetEfficiency());
-        REQUIRE(h2->GetPoints() == 0);
-        REQUIRE(h2->GetAge() == 0);
+        REQUIRE(host2->GetIntVal() == host1->GetIntVal());
+        REQUIRE(host2->GetEfficiency() == host1->GetEfficiency());
+        REQUIRE(host2->GetPoints() == 0);
+        REQUIRE(host2->GetAge() == 0);
         //check that the offspring is the correct class
-        REQUIRE(typeid(*h2).name() == typeid(*h1).name());
+        REQUIRE(typeid(*host2).name() == typeid(*host1).name());
     }
+    host1.Delete();
+    host2.Delete();
 }
 
 TEST_CASE("EfficientHost SetEfficiency and GetEfficiency", "[efficient]"){
@@ -65,12 +71,12 @@ TEST_CASE("EfficientHost SetEfficiency and GetEfficiency", "[efficient]"){
     EfficientWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<EfficientHost> h = new EfficientHost(random, world, &config, int_val);
+    emp::Ptr<EfficientHost> host = emp::NewPtr<EfficientHost>(random, world, &config, int_val);
 
     double efficiency = 0.5;
-    h->SetEfficiency(efficiency);
+    host->SetEfficiency(efficiency);
     double expected_efficieny = 0.5;
-    REQUIRE(h->GetEfficiency() == expected_efficieny);
+    REQUIRE(host->GetEfficiency() == expected_efficieny);
 
-    delete h;
+    host.Delete();
 }

--- a/source/test/efficient_mode_test/EfficientSymbiont.test.cc
+++ b/source/test/efficient_mode_test/EfficientSymbiont.test.cc
@@ -13,7 +13,7 @@ TEST_CASE("EfficientSymbiont Constructor", "[efficient]"){
     int_val = -1;
     EfficientSymbiont * s1 = new EfficientSymbiont(random, world, &config, int_val);
     CHECK(s1->GetIntVal() == int_val);
-    CHECK(s1->GetAge() == 0); 
+    CHECK(s1->GetAge() == 0);
     CHECK(s1->GetPoints() == 0);
 
     int_val = -1;
@@ -49,7 +49,7 @@ TEST_CASE("EfficientSymbiont mutate", "[efficient]") {
         config.MUTATION_SIZE(0.002);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
 
-        s->mutate("vertical");
+        s->Mutate("vertical");
 
         THEN("Mutation occurs and efficiency value changes, but within bounds") {
             REQUIRE(s->GetEfficiency() != orig_efficiency);
@@ -69,7 +69,7 @@ TEST_CASE("EfficientSymbiont mutate", "[efficient]") {
         config.MUTATION_SIZE(0);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
 
-        s->mutate("vertical");
+        s->Mutate("vertical");
 
 
         THEN("Mutation does not occur and efficiency value does not change") {
@@ -138,10 +138,10 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         config.INT_VAL_MUT_RATE(0);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
 
-        s->mutate("vertical");
+        s->Mutate("vertical");
 
         THEN("Efficiency mutates but interaction value does not") {
-            
+
             REQUIRE(s->GetEfficiency() != orig_efficiency);
             REQUIRE(s->GetEfficiency() <= 1);
             REQUIRE(s->GetEfficiency() >= 0);
@@ -157,17 +157,17 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         config.INT_VAL_MUT_RATE(0);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
 
-        s->mutate("horizontal");
+        s->Mutate("horizontal");
 
         THEN("Efficiency mutates but interaction value does not") {
-            
+
             REQUIRE(s->GetEfficiency() != orig_efficiency);
             REQUIRE(s->GetEfficiency() <= 1);
             REQUIRE(s->GetEfficiency() >= 0);
             REQUIRE(s->GetIntVal() == int_val);
         }
 
-        
+
     }
 
     WHEN("Mutation rate is zero, but interaction value mut rate is not zero and vertical transmission occurs") {
@@ -179,10 +179,10 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         config.INT_VAL_MUT_RATE(1);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
 
-        s->mutate("vertical");
+        s->Mutate("vertical");
 
         THEN("Efficiency does not mutate but interaction value does") {
-            
+
             REQUIRE(s->GetEfficiency() == orig_efficiency);
             REQUIRE(s->GetIntVal() <= 1);
             REQUIRE(s->GetIntVal() >= -1);
@@ -199,17 +199,17 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         config.INT_VAL_MUT_RATE(1);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
 
-        s->mutate("horizontal");
+        s->Mutate("horizontal");
 
         THEN("Efficiency does not mutate but interaction value does") {
-            
+
             REQUIRE(s->GetEfficiency() == orig_efficiency);
             REQUIRE(s->GetIntVal() <= 1);
             REQUIRE(s->GetIntVal() >= -1);
             REQUIRE(s->GetIntVal() != int_val);
         }
 
-        
+
     }
 
 
@@ -234,7 +234,7 @@ TEST_CASE("EfficientSymbiont reproduce", "[efficient]") {
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, parent_orig_efficiency);
         s->SetAge(10);
 
-        emp::Ptr<Organism> sym_baby = s->reproduce("vertical");
+        emp::Ptr<Organism> sym_baby = s->Reproduce("vertical");
 
 
         THEN("Offspring's efficiency equals parent's efficiency") {
@@ -267,7 +267,7 @@ TEST_CASE("EfficientSymbiont reproduce", "[efficient]") {
         config.MUTATION_SIZE(0.01);
         EfficientSymbiont * s2 = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
 
-        emp::Ptr<Organism> sym_baby = s2->reproduce("vertical");
+        emp::Ptr<Organism> sym_baby = s2->Reproduce("vertical");
 
 
         THEN("Offspring's efficiency value does not equal parent's efficiency value") {
@@ -308,7 +308,7 @@ TEST_CASE("EfficientSymbiont HorizMutate", "[efficient]") {
         config.EFFICIENCY_MUT_RATE(1);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
 
-        s->mutate("horizontal");
+        s->Mutate("horizontal");
 
         THEN("Efficiency changes during horizontal mutation, int val stays the same") {
             REQUIRE(s->GetEfficiency() != efficiency);
@@ -334,7 +334,7 @@ TEST_CASE("EfficientSymbiont mutate with horizontal transmission", "[efficient]"
         config.EFFICIENCY_MUT_RATE(1);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
 
-        s->mutate("horizontal");
+        s->Mutate("horizontal");
 
         THEN("Efficiency changes during horizontal mutation, int val stays the same") {
             REQUIRE(s->GetEfficiency() != efficiency);
@@ -360,7 +360,7 @@ TEST_CASE("EfficientSymbiont mutate with vertical transmission", "[efficient]") 
         config.EFFICIENCY_MUT_RATE(-1);
         EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
 
-        s->mutate("vertical");
+        s->Mutate("vertical");
 
         THEN("Efficiency and int val should change because pulls from regular mutation rate") {
             REQUIRE(s->GetEfficiency() != efficiency);
@@ -412,7 +412,7 @@ TEST_CASE("EfficientSymbiont's Process called from Host when mutation rate and s
                 new_infected = h4;
             }
             REQUIRE(new_infected != nullptr);
-            REQUIRE(new_infected->HasSym()); 
+            REQUIRE(new_infected->HasSym());
             REQUIRE(new_infected->GetSymbionts()[0]->GetEfficiency() == efficiency);
         }
 
@@ -445,7 +445,7 @@ TEST_CASE("EfficientSymbiont's Process called from Host when mutation rate and s
                 new_infected = h4;
             }
             REQUIRE(new_infected != nullptr);
-            REQUIRE(new_infected->HasSym()); 
+            REQUIRE(new_infected->HasSym());
             REQUIRE(new_infected->GetSymbionts()[0]->GetEfficiency() != efficiency);
             REQUIRE(new_infected->GetSymbionts()[0]->GetIntVal() != int_val);
         }
@@ -453,14 +453,14 @@ TEST_CASE("EfficientSymbiont's Process called from Host when mutation rate and s
     }
 }
 
-TEST_CASE("EfficientSymbiont makeNew", "[efficient]"){
+TEST_CASE("EfficientSymbiont MakeNew", "[efficient]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     EfficientWorld w(*random);
     SymConfigBase config;
 
     double sym_int_val = 0.2;
     Organism * s1 = new EfficientSymbiont(random, &w, &config, sym_int_val);
-    Organism * s2 = s1->makeNew();
+    Organism * s2 = s1->MakeNew();
 
     THEN("The new efficient symbiont has the same genome as its parent, but age and points 0"){
         REQUIRE(s2->GetIntVal() == s1->GetIntVal());

--- a/source/test/efficient_mode_test/EfficientSymbiont.test.cc
+++ b/source/test/efficient_mode_test/EfficientSymbiont.test.cc
@@ -8,31 +8,36 @@ TEST_CASE("EfficientSymbiont Constructor", "[efficient]"){
     EfficientWorld * world = &w;
 
     double int_val = -2;
-    REQUIRE_THROWS( new EfficientSymbiont(random, world, &config, int_val) );
+    REQUIRE_THROWS( emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val) );
 
     int_val = -1;
-    EfficientSymbiont * s1 = new EfficientSymbiont(random, world, &config, int_val);
-    CHECK(s1->GetIntVal() == int_val);
-    CHECK(s1->GetAge() == 0);
-    CHECK(s1->GetPoints() == 0);
+    emp::Ptr<EfficientSymbiont> symbiont1 = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val);
+    CHECK(symbiont1->GetIntVal() == int_val);
+    CHECK(symbiont1->GetAge() == 0);
+    CHECK(symbiont1->GetPoints() == 0);
 
     int_val = -1;
     double points = 10;
     double efficiency = 0.5;
-    EfficientSymbiont * s2 = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
-    CHECK(s2->GetIntVal() == int_val);
-    CHECK(s2->GetEfficiency() == efficiency);
-    CHECK(s2->GetAge() == 0);
-    CHECK(s2->GetPoints() == points);
+
+    emp::Ptr<EfficientSymbiont> symbiont2 = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
+    CHECK(symbiont2->GetIntVal() == int_val);
+    CHECK(symbiont2->GetEfficiency() == efficiency);
+    CHECK(symbiont2->GetAge() == 0);
+    CHECK(symbiont2->GetPoints() == points);
 
     int_val = 1;
-    EfficientSymbiont * s3 = new EfficientSymbiont(random, world, &config, int_val);
-    CHECK(s3->GetIntVal() == int_val);
-    CHECK(s3->GetAge() == 0);
-    CHECK(s3->GetPoints() == 0);
+    emp::Ptr<EfficientSymbiont> symbiont3 = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val);
+    CHECK(symbiont3->GetIntVal() == int_val);
+    CHECK(symbiont3->GetAge() == 0);
+    CHECK(symbiont3->GetPoints() == 0);
 
     int_val = 2;
-    REQUIRE_THROWS(new EfficientSymbiont(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val) );
+
+    symbiont1.Delete();
+    symbiont2.Delete();
+    symbiont3.Delete();
 }
 
 TEST_CASE("EfficientSymbiont mutate", "[efficient]") {
@@ -47,15 +52,16 @@ TEST_CASE("EfficientSymbiont mutate", "[efficient]") {
         double orig_efficiency = 0.5;
         double points = 0;
         config.MUTATION_SIZE(0.002);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, orig_efficiency);
 
-        s->Mutate("vertical");
+        symbiont->Mutate("vertical");
 
         THEN("Mutation occurs and efficiency value changes, but within bounds") {
-            REQUIRE(s->GetEfficiency() != orig_efficiency);
-            REQUIRE(s->GetEfficiency() <= 1);
-            REQUIRE(s->GetEfficiency() >= 0);
+            REQUIRE(symbiont->GetEfficiency() != orig_efficiency);
+            REQUIRE(symbiont->GetEfficiency() <= 1);
+            REQUIRE(symbiont->GetEfficiency() >= 0);
         }
+        symbiont.Delete();
     }
 
 
@@ -67,15 +73,15 @@ TEST_CASE("EfficientSymbiont mutate", "[efficient]") {
         config.HORIZ_TRANS(true);
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, orig_efficiency);
 
-        s->Mutate("vertical");
+        symbiont->Mutate("vertical");
 
 
         THEN("Mutation does not occur and efficiency value does not change") {
-            REQUIRE(s->GetEfficiency() == orig_efficiency);
+            REQUIRE(symbiont->GetEfficiency() == orig_efficiency);
         }
-
+        symbiont.Delete();
     }
 }
 
@@ -90,37 +96,40 @@ TEST_CASE("EfficientSymbiont AddPoints", "[efficient]") {
 
     WHEN("Efficiency is 1") {
         double efficiency = 1;
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        s->AddPoints(points_in);
+        symbiont->AddPoints(points_in);
 
         THEN("All points added") {
-            REQUIRE( s->GetPoints() == points_in);
+            REQUIRE( symbiont->GetPoints() == points_in);
         }
+        symbiont.Delete();
     }
 
     WHEN("Efficiency is 0.5") {
         double efficiency = 0.5;
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        s->AddPoints(points_in);
+        symbiont->AddPoints(points_in);
         double actual_points = 5; //points_in * 0.5
 
         THEN("Half points get added") {
-            REQUIRE( s->GetPoints() == actual_points);
+            REQUIRE( symbiont->GetPoints() == actual_points);
         }
+        symbiont.Delete();
     }
 
     WHEN("Efficiency is 0") {
         double efficiency = 0;
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        s->AddPoints(points_in);
+        symbiont->AddPoints(points_in);
         double actual_points = 0; //points_in * 0
 
         THEN("No points get added") {
-            REQUIRE( s->GetPoints() == actual_points);
+            REQUIRE( symbiont->GetPoints() == actual_points);
         }
+        symbiont.Delete();
     }
 }
 
@@ -136,18 +145,18 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         double points = 0;
         config.MUTATION_SIZE(0.002);
         config.INT_VAL_MUT_RATE(0);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, orig_efficiency);
 
-        s->Mutate("vertical");
+        symbiont->Mutate("vertical");
 
         THEN("Efficiency mutates but interaction value does not") {
 
-            REQUIRE(s->GetEfficiency() != orig_efficiency);
-            REQUIRE(s->GetEfficiency() <= 1);
-            REQUIRE(s->GetEfficiency() >= 0);
-            REQUIRE(s->GetIntVal() == int_val);
+            REQUIRE(symbiont->GetEfficiency() != orig_efficiency);
+            REQUIRE(symbiont->GetEfficiency() <= 1);
+            REQUIRE(symbiont->GetEfficiency() >= 0);
+            REQUIRE(symbiont->GetIntVal() == int_val);
         }
-
+        symbiont.Delete();
     }
     WHEN("Mutation rate is not zero, but interaction value mut rate is 0 and horizontal transmission occurs") {
         double int_val = 0;
@@ -155,19 +164,18 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         double points = 0;
         config.MUTATION_SIZE(0.002);
         config.INT_VAL_MUT_RATE(0);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, orig_efficiency);
 
-        s->Mutate("horizontal");
+        symbiont->Mutate("horizontal");
 
         THEN("Efficiency mutates but interaction value does not") {
 
-            REQUIRE(s->GetEfficiency() != orig_efficiency);
-            REQUIRE(s->GetEfficiency() <= 1);
-            REQUIRE(s->GetEfficiency() >= 0);
-            REQUIRE(s->GetIntVal() == int_val);
+            REQUIRE(symbiont->GetEfficiency() != orig_efficiency);
+            REQUIRE(symbiont->GetEfficiency() <= 1);
+            REQUIRE(symbiont->GetEfficiency() >= 0);
+            REQUIRE(symbiont->GetIntVal() == int_val);
         }
-
-
+        symbiont.Delete();
     }
 
     WHEN("Mutation rate is zero, but interaction value mut rate is not zero and vertical transmission occurs") {
@@ -177,18 +185,18 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(0);
         config.INT_VAL_MUT_RATE(1);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, orig_efficiency);
 
-        s->Mutate("vertical");
+        symbiont->Mutate("vertical");
 
         THEN("Efficiency does not mutate but interaction value does") {
 
-            REQUIRE(s->GetEfficiency() == orig_efficiency);
-            REQUIRE(s->GetIntVal() <= 1);
-            REQUIRE(s->GetIntVal() >= -1);
-            REQUIRE(s->GetIntVal() != int_val);
+            REQUIRE(symbiont->GetEfficiency() == orig_efficiency);
+            REQUIRE(symbiont->GetIntVal() <= 1);
+            REQUIRE(symbiont->GetIntVal() >= -1);
+            REQUIRE(symbiont->GetIntVal() != int_val);
         }
-
+        symbiont.Delete();
     }
     WHEN("Mutation rate is zero, but interaction value mut rate is not zero and horizontal transmission occurs") {
         double int_val = 0;
@@ -197,18 +205,18 @@ TEST_CASE("INT_VAL_MUT_RATE", "[efficient]") {
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(0);
         config.INT_VAL_MUT_RATE(1);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, orig_efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, orig_efficiency);
 
-        s->Mutate("horizontal");
+        symbiont->Mutate("horizontal");
 
         THEN("Efficiency does not mutate but interaction value does") {
 
-            REQUIRE(s->GetEfficiency() == orig_efficiency);
-            REQUIRE(s->GetIntVal() <= 1);
-            REQUIRE(s->GetIntVal() >= -1);
-            REQUIRE(s->GetIntVal() != int_val);
+            REQUIRE(symbiont->GetEfficiency() == orig_efficiency);
+            REQUIRE(symbiont->GetIntVal() <= 1);
+            REQUIRE(symbiont->GetIntVal() >= -1);
+            REQUIRE(symbiont->GetIntVal() != int_val);
         }
-
+        symbiont.Delete();
 
     }
 
@@ -231,29 +239,29 @@ TEST_CASE("EfficientSymbiont reproduce", "[efficient]") {
         config.SYM_HORIZ_TRANS_RES(100.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, parent_orig_efficiency);
-        s->SetAge(10);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, parent_orig_efficiency);
+        symbiont->SetAge(10);
 
-        emp::Ptr<Organism> sym_baby = s->Reproduce("vertical");
+        emp::Ptr<Organism> sym_baby = symbiont->Reproduce("vertical");
 
 
-        THEN("Offspring's efficiency equals parent's efficiency") {
+        THEN("Offspring'symbiont efficiency equals parent'symbiont efficiency") {
             double sym_baby_efficiency = 0.5;
             REQUIRE( sym_baby->GetEfficiency() == sym_baby_efficiency);
             REQUIRE( sym_baby->GetEfficiency() == parent_orig_efficiency);
-            REQUIRE( s->GetEfficiency() == parent_orig_efficiency);
+            REQUIRE( symbiont->GetEfficiency() == parent_orig_efficiency);
         }
 
-        THEN("Offspring's points are zero") {
+        THEN("Offspring'symbiont points are zero") {
             int sym_baby_points = 0;
             REQUIRE( sym_baby->GetPoints() == sym_baby_points);
 
         }
 
-        THEN("Offspring's age is 0") {
+        THEN("Offspring'symbiont age is 0") {
             REQUIRE(sym_baby->GetAge() == 0);
         }
-
+        symbiont.Delete();
         sym_baby.Delete();
     }
 
@@ -265,27 +273,27 @@ TEST_CASE("EfficientSymbiont reproduce", "[efficient]") {
         config.SYM_HORIZ_TRANS_RES(100.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0.01);
-        EfficientSymbiont * s2 = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont2 = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        emp::Ptr<Organism> sym_baby = s2->Reproduce("vertical");
+        emp::Ptr<Organism> sym_baby = symbiont2->Reproduce("vertical");
 
 
-        THEN("Offspring's efficiency value does not equal parent's efficiency value") {
-            REQUIRE( sym_baby->GetEfficiency() != parent_orig_efficiency);
+        THEN("Offspring'symbiont efficiency value does not equal parent'symbiont efficiency value") {
+            REQUIRE(sym_baby->GetEfficiency() != parent_orig_efficiency);
             REQUIRE(sym_baby->GetEfficiency() <= 1);
             REQUIRE(sym_baby->GetEfficiency() >= 0);
         }
 
-        THEN("Offspring's points are zero") {
+        THEN("Offspring'symbiont points are zero") {
             int sym_baby_points = 0;
             REQUIRE( sym_baby->GetPoints() == sym_baby_points);
 
         }
 
-        THEN("Offspring's age is 0") {
+        THEN("Offspring'symbiont age is 0") {
             REQUIRE(sym_baby->GetAge() == 0);
         }
-
+        symbiont2.Delete();
         sym_baby.Delete();
 
     }
@@ -306,15 +314,15 @@ TEST_CASE("EfficientSymbiont HorizMutate", "[efficient]") {
         config.MUTATION_RATE(0);
         config.HORIZ_MUTATION_RATE(0);
         config.EFFICIENCY_MUT_RATE(1);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        s->Mutate("horizontal");
+        symbiont->Mutate("horizontal");
 
         THEN("Efficiency changes during horizontal mutation, int val stays the same") {
-            REQUIRE(s->GetEfficiency() != efficiency);
-            REQUIRE(s->GetIntVal() == int_val);
+            REQUIRE(symbiont->GetEfficiency() != efficiency);
+            REQUIRE(symbiont->GetIntVal() == int_val);
         }
-
+        symbiont.Delete();
     }
 }
 
@@ -332,15 +340,15 @@ TEST_CASE("EfficientSymbiont mutate with horizontal transmission", "[efficient]"
         config.MUTATION_RATE(0);
         config.HORIZ_MUTATION_RATE(0);
         config.EFFICIENCY_MUT_RATE(1);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        s->Mutate("horizontal");
+        symbiont->Mutate("horizontal");
 
         THEN("Efficiency changes during horizontal mutation, int val stays the same") {
-            REQUIRE(s->GetEfficiency() != efficiency);
-            REQUIRE(s->GetIntVal() == int_val);
+            REQUIRE(symbiont->GetEfficiency() != efficiency);
+            REQUIRE(symbiont->GetIntVal() == int_val);
         }
-
+        symbiont.Delete();
     }
 }
 
@@ -358,19 +366,19 @@ TEST_CASE("EfficientSymbiont mutate with vertical transmission", "[efficient]") 
         config.MUTATION_RATE(1);
         config.HORIZ_MUTATION_RATE(0);
         config.EFFICIENCY_MUT_RATE(-1);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
 
-        s->Mutate("vertical");
+        symbiont->Mutate("vertical");
 
         THEN("Efficiency and int val should change because pulls from regular mutation rate") {
-            REQUIRE(s->GetEfficiency() != efficiency);
-            REQUIRE(s->GetIntVal() != int_val);
+            REQUIRE(symbiont->GetEfficiency() != efficiency);
+            REQUIRE(symbiont->GetIntVal() != int_val);
         }
-
+        symbiont.Delete();
     }
 }
 
-TEST_CASE("EfficientSymbiont's Process called from Host when mutation rate and size are zero", "[efficient]") {
+TEST_CASE("EfficientSymbiont'symbiont Process called from Host when mutation rate and size are zero", "[efficient]") {
     emp::Ptr<emp::Random> random = new emp::Random(25);
     random->GetUInt(0, 1); //issue with random number generator led to location 0 being picked for most random seeds on the first random number
     SymConfigBase config;
@@ -387,62 +395,61 @@ TEST_CASE("EfficientSymbiont's Process called from Host when mutation rate and s
     double host_interaction_val = 1;
     double host_points = 0;
 
-    WHEN("The horizontal transmission mutation rate and size are also zero and an EfficientSymbiont is added to a Host and about to reproduce horizontally and Host's Process is called") {
+    WHEN("The horizontal transmission mutation rate and size are also zero and an EfficientSymbiont is added to a Host and about to reproduce horizontally and Host'symbiont Process is called") {
+        emp::Ptr<EfficientHost> host = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
 
-        EfficientHost * h = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientHost * h2 = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientHost * h3 = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientHost * h4 = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
-        h->AddSymbiont(s);
-        w.AddOrgAt(h, 0);
-        w.AddOrgAt(h2, 1);
-        w.AddOrgAt(h3, 2);
-        w.AddOrgAt(h4, 3);
+        emp::Ptr<EfficientHost> host2 = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
+        emp::Ptr<EfficientHost> host3 = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
+        emp::Ptr<EfficientHost> host4 = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
+        host->AddSymbiont(symbiont);
+        w.AddOrgAt(host, 0);
+        w.AddOrgAt(host2, 1);
+        w.AddOrgAt(host3, 2);
+        w.AddOrgAt(host4, 3);
 
-        h->Process(0);
+        host->Process(0);
 
         THEN("EfficientSymbiont reproduces and offspring goes into neighboring Host and offspring has identical efficiency value") {
-            EfficientHost * new_infected = nullptr;
-            if(h2->HasSym()) {
-                new_infected = h2;
-            } else if (h3->HasSym()) {
-                new_infected = h3;
-            } else if(h4->HasSym()) {
-                new_infected = h4;
+            emp::Ptr<EfficientHost> new_infected = nullptr;
+            if(host2->HasSym()) {
+                new_infected = host2;
+            } else if (host3->HasSym()) {
+                new_infected = host3;
+            } else if(host4->HasSym()) {
+                new_infected = host4;
             }
             REQUIRE(new_infected != nullptr);
             REQUIRE(new_infected->HasSym());
             REQUIRE(new_infected->GetSymbionts()[0]->GetEfficiency() == efficiency);
         }
-
     }
 
-    WHEN("The horizontal mutation rate and size are not zero and an EfficientSymbiont is added to a Host and about to reproduce horizontally and Host's Process is called") {
+    WHEN("The horizontal mutation rate and size are not zero and an EfficientSymbiont is added to a Host and about to reproduce horizontally and Host'symbiont Process is called") {
         config.HORIZ_MUTATION_SIZE(0.002);
         config.HORIZ_MUTATION_RATE(1.0);
-        EfficientHost * h = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientHost * h2 = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientHost * h3 = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
-        EfficientHost * h4 = new EfficientHost(random, &w, &config, host_interaction_val, {}, {}, std::set<int>(), host_points);
+        emp::Ptr<EfficientHost> host = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
+        emp::Ptr<EfficientHost> host2 = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
+        emp::Ptr<EfficientHost> host3 = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
+        emp::Ptr<EfficientHost> host4 = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);
 
-        EfficientSymbiont * s = new EfficientSymbiont(random, world, &config, int_val, points, efficiency);
-        h->AddSymbiont(s);
-        w.AddOrgAt(h, 0);
-        w.AddOrgAt(h2, 1);
-        w.AddOrgAt(h3, 2);
-        w.AddOrgAt(h4, 3);
+        emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val, points, efficiency);
+        host->AddSymbiont(symbiont);
+        w.AddOrgAt(host, 0);
+        w.AddOrgAt(host2, 1);
+        w.AddOrgAt(host3, 2);
+        w.AddOrgAt(host4, 3);
 
-        h->Process(0);
+        host->Process(0);
 
         THEN("EfficientSymbiont reproduces and offspring with a different efficiency value goes into neighboring Host") {
-            EfficientHost * new_infected = nullptr;
-            if(h2->HasSym()) {
-                new_infected = h2;
-            } else if (h3->HasSym()) {
-                new_infected = h3;
-            } else if(h4->HasSym()) {
-                new_infected = h4;
+            emp::Ptr<EfficientHost> new_infected = nullptr;
+            if(host2->HasSym()) {
+                new_infected = host2;
+            } else if (host3->HasSym()) {
+                new_infected = host3;
+            } else if(host4->HasSym()) {
+                new_infected = host4;
             }
             REQUIRE(new_infected != nullptr);
             REQUIRE(new_infected->HasSym());
@@ -459,18 +466,20 @@ TEST_CASE("EfficientSymbiont MakeNew", "[efficient]"){
     SymConfigBase config;
 
     double sym_int_val = 0.2;
-    Organism * s1 = new EfficientSymbiont(random, &w, &config, sym_int_val);
-    Organism * s2 = s1->MakeNew();
+    emp::Ptr<Organism> symbiont1 = emp::NewPtr<EfficientSymbiont>(random, &w, &config, sym_int_val);
+    emp::Ptr<Organism> symbiont2 = symbiont1->MakeNew();
 
     THEN("The new efficient symbiont has the same genome as its parent, but age and points 0"){
-        REQUIRE(s2->GetIntVal() == s1->GetIntVal());
-        REQUIRE(s2->GetInfectionChance() == s1->GetInfectionChance());
-        REQUIRE(s2->GetEfficiency() == s1->GetEfficiency());
-        REQUIRE(s2->GetAge() == 0);
-        REQUIRE(s2->GetPoints() == 0);
+        REQUIRE(symbiont2->GetIntVal() == symbiont1->GetIntVal());
+        REQUIRE(symbiont2->GetInfectionChance() == symbiont1->GetInfectionChance());
+        REQUIRE(symbiont2->GetEfficiency() == symbiont1->GetEfficiency());
+        REQUIRE(symbiont2->GetAge() == 0);
+        REQUIRE(symbiont2->GetPoints() == 0);
         //check that the offspring is the correct class
-        REQUIRE(typeid(*s2).name() == typeid(*s1).name());
+        REQUIRE(typeid(*symbiont2).name() == typeid(*symbiont1).name());
     }
+    symbiont1.Delete();
+    symbiont2.Delete();
 }
 
 TEST_CASE("EfficientSymbiont SetEfficiency and GetEfficiency", "[efficient]"){
@@ -479,12 +488,12 @@ TEST_CASE("EfficientSymbiont SetEfficiency and GetEfficiency", "[efficient]"){
     EfficientWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<EfficientSymbiont> s = new EfficientSymbiont(random, world, &config, int_val);
+    emp::Ptr<EfficientSymbiont> symbiont = emp::NewPtr<EfficientSymbiont>(random, world, &config, int_val);
 
     double efficiency = 0.5;
-    s->SetEfficiency(efficiency);
+    symbiont->SetEfficiency(efficiency);
     double expected_efficieny = 0.5;
-    REQUIRE(s->GetEfficiency() == expected_efficieny);
+    REQUIRE(symbiont->GetEfficiency() == expected_efficieny);
 
-    delete s;
+    symbiont.Delete();
 }

--- a/source/test/efficient_mode_test/EfficientSymbiont.test.cc
+++ b/source/test/efficient_mode_test/EfficientSymbiont.test.cc
@@ -393,7 +393,6 @@ TEST_CASE("EfficientSymbiont'symbiont Process called from Host when mutation rat
     double int_val = 0;
     double efficiency = 0.9;
     double host_interaction_val = 1;
-    double host_points = 0;
 
     WHEN("The horizontal transmission mutation rate and size are also zero and an EfficientSymbiont is added to a Host and about to reproduce horizontally and Host'symbiont Process is called") {
         emp::Ptr<EfficientHost> host = emp::NewPtr<EfficientHost>(random, &w, &config, host_interaction_val);

--- a/source/test/lysis_mode_test/Bacterium.test.cc
+++ b/source/test/lysis_mode_test/Bacterium.test.cc
@@ -8,21 +8,21 @@ TEST_CASE("Bacterium constructor, host_incorporation_val", "[lysis]"){
     double int_val = -1;
 
     config.HOST_INC_VAL(-1);
-    Bacterium * b = new Bacterium(random, world, &config, int_val);
-    CHECK(b->GetIncVal() >= 0.0);
-    CHECK(b->GetIncVal() <= 1.0);
-    CHECK(b->GetAge() == 0); 
-    CHECK(b->GetPoints() == 0);
+    emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+    CHECK(bacterium->GetIncVal() >= 0.0);
+    CHECK(bacterium->GetIncVal() <= 1.0);
+    CHECK(bacterium->GetAge() == 0);
+    CHECK(bacterium->GetPoints() == 0);
 
     config.HOST_INC_VAL(0.8);
-    Bacterium * b2 = new Bacterium(random, world, &config, int_val);
+    emp::Ptr<Bacterium> bacterium2 = emp::NewPtr<Bacterium>(random, world, &config, int_val);
     double expected_inc_val = 0.8;
-    CHECK(b2->GetIncVal()==expected_inc_val);
-    CHECK(b2->GetAge() == 0); 
-    CHECK(b2->GetPoints() == 0);
+    CHECK(bacterium2->GetIncVal()==expected_inc_val);
+    CHECK(bacterium2->GetAge() == 0);
+    CHECK(bacterium2->GetPoints() == 0);
 
-    delete b;
-    delete b2;
+    bacterium.Delete();
+    bacterium2.Delete();
 }
 
 TEST_CASE("Bacterium SetIncVal, GetIncVal", "[lysis]"){
@@ -31,13 +31,14 @@ TEST_CASE("Bacterium SetIncVal, GetIncVal", "[lysis]"){
     LysisWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
+    emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
 
     double host_incorporation_val = 0.2;
-    b->SetIncVal(host_incorporation_val);
+    bacterium->SetIncVal(host_incorporation_val);
     double expected_inc_val = 0.2;
-    REQUIRE(b->GetIncVal()==expected_inc_val);
+    REQUIRE(bacterium->GetIncVal()==expected_inc_val);
 
+    bacterium.Delete();
 }
 
 TEST_CASE("Bacterium mutate", "[lysis]"){
@@ -54,59 +55,61 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(1);
         config.MUTATE_INC_VAL(1);
-        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
-        b->mutate();
+      //  emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+        //working version:
+        emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+        bacterium->mutate();
 
         THEN("Then mutation occurs and the bacterium's host_inc_val mutates"){
-            REQUIRE(b->GetIncVal() != orig_host_inc_val);
-            REQUIRE(b->GetIncVal() >= 0.0);
-            REQUIRE(b->GetIncVal() <= 1.0);
+            REQUIRE(bacterium->GetIncVal() != orig_host_inc_val);
+            REQUIRE(bacterium->GetIncVal() >= 0.0);
+            REQUIRE(bacterium->GetIncVal() <= 1.0);
         }
 
-    delete b;
+    bacterium.Delete();
     }
 
     WHEN("Mutation rate is not zero and host_inc_val mutations are not enabled"){
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(1);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
-        b->mutate();
+        emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+        bacterium->mutate();
 
         THEN("Then mutations occur but do not occur in the host_inc_val"){
-            REQUIRE(b->GetIncVal() ==  orig_host_inc_val);
+            REQUIRE(bacterium->GetIncVal() ==  orig_host_inc_val);
         }
 
-    delete b;
+    bacterium.Delete();
     }
 
     WHEN("Mutation rate is 0 and host_inc_val mutations are enabled"){
         config.MUTATION_RATE(0.0);
         config.MUTATION_SIZE(0.0);
         config.MUTATE_INC_VAL(1);
-        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
-        b->mutate();
+        emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+        bacterium->mutate();
 
         THEN("Mutations do not occur"){
-            REQUIRE(b->GetIncVal() ==  orig_host_inc_val);
+            REQUIRE(bacterium->GetIncVal() ==  orig_host_inc_val);
         }
 
-    delete b;
+    bacterium.Delete();
     }
 
     WHEN("Mutation rate is 0 and host_inc_val mutations are not enabled"){
         config.MUTATION_RATE(0.0);
         config.MUTATION_SIZE(0.0);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Organism> b = new Bacterium(random, world, &config, int_val);
-        b->mutate();
+        emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+        bacterium->mutate();
 
         THEN("Mutations do not occur"){
-            REQUIRE(b->GetIncVal() ==  orig_host_inc_val);
+            REQUIRE(bacterium->GetIncVal() ==  orig_host_inc_val);
         }
 
-    delete b;
-    }
+    bacterium.Delete();
+  }
 }
 
 TEST_CASE("ProcessLysogenResources", "[lysis]"){
@@ -119,40 +122,41 @@ TEST_CASE("ProcessLysogenResources", "[lysis]"){
 
     double orig_host_resources = 10;
     double int_val = 0;
-    emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
+    emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
 
     WHEN("The incorporation values are similar"){
         double phage_inc_val = 0;
-        b->SetResInProcess(orig_host_resources);
-        double expected_resources = 20; //synergy * b->GetResInProcess() * (1 - abs(host_inc_val - phage_inc_val))
+        bacterium->SetResInProcess(orig_host_resources);
+        double expected_resources = 20; //synergy * bacterium->GetResInProcess() * (1 - abs(host_inc_val - phage_inc_val))
 
         THEN("The host resources increase"){
-            REQUIRE(b->ProcessLysogenResources(phage_inc_val) == expected_resources);
-            REQUIRE(b->GetResInProcess() == 0);
+            REQUIRE(bacterium->ProcessLysogenResources(phage_inc_val) == expected_resources);
+            REQUIRE(bacterium->GetResInProcess() == 0);
         }
     }
 
     WHEN("The incorporation values are neutral"){
         double phage_inc_val = 0.5;
-        b->SetResInProcess(orig_host_resources);
-        double expected_resources = 10; //synergy * b->GetResInProcess() * (1 - abs(host_inc_val - phage_inc_val))
+        bacterium->SetResInProcess(orig_host_resources);
+        double expected_resources = 10; //synergy * bacterium->GetResInProcess() * (1 - abs(host_inc_val - phage_inc_val))
 
         THEN("The host resources stay the same"){
-            REQUIRE(b->ProcessLysogenResources(phage_inc_val) == expected_resources);
-            REQUIRE(b->GetResInProcess() == 0);
+            REQUIRE(bacterium->ProcessLysogenResources(phage_inc_val) == expected_resources);
+            REQUIRE(bacterium->GetResInProcess() == 0);
         }
     }
 
     WHEN("The incorporation values are far apart"){
         double phage_inc_val = 1;
-        b->SetResInProcess(orig_host_resources);
-        double expected_resources = 0; //synergy * b->GetResInProcess() * (1 - abs(host_inc_val - phage_inc_val))
+        bacterium->SetResInProcess(orig_host_resources);
+        double expected_resources = 0; //synergy * bacterium->GetResInProcess() * (1 - abs(host_inc_val - phage_inc_val))
 
         THEN("The host resources are diminished"){
-            REQUIRE(b->ProcessLysogenResources(phage_inc_val) == expected_resources);
-            REQUIRE(b->GetResInProcess() == 0);
+            REQUIRE(bacterium->ProcessLysogenResources(phage_inc_val) == expected_resources);
+            REQUIRE(bacterium->GetResInProcess() == 0);
         }
     }
+    bacterium.Delete();
 }
 
 TEST_CASE("Bacterium Process", "[lysis]"){
@@ -170,12 +174,13 @@ TEST_CASE("Bacterium Process", "[lysis]"){
             config.RES_DISTRIBUTE(5);
 
             double int_val = 0;
-            emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
-            b->Process(location);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+            bacterium->Process(location);
 
             THEN("The bacterium's points increase by res distribute"){
-                REQUIRE(b->GetPoints() == res_distribute);
+                REQUIRE(bacterium->GetPoints() == res_distribute);
             }
+            bacterium.Delete();
         }
 
         WHEN("The bacterium does have enough resources to reproduce"){
@@ -184,20 +189,18 @@ TEST_CASE("Bacterium Process", "[lysis]"){
             world->SetResPerUpdate(res_distribute);
 
             double int_val = 0;
-            emp::Ptr<Bacterium> b = new Bacterium(random, world, &config, int_val);
-            b->Process(location);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
+            bacterium->Process(location);
 
             THEN("The bacterium will reproduce and its points will be set to zero"){
-                REQUIRE(b->GetPoints() == 0);
+                REQUIRE(bacterium->GetPoints() == 0);
             }
+            bacterium.Delete();
         }
     }
 }
 
 TEST_CASE("Phage Exclude", "[lysis]") {
-    emp::Ptr<emp::Random> random = new emp::Random(3);
-    SymWorld w(*random);
-
     SymConfigBase config;
     int sym_limit = 4;
     config.SYM_LIMIT(sym_limit);
@@ -205,19 +208,22 @@ TEST_CASE("Phage Exclude", "[lysis]") {
     double int_val = 0;
 
     WHEN("Phage exclude is set to false"){
+      emp::Ptr<emp::Random> random = new emp::Random(3);
+      LysisWorld w(*random);
+
       bool phage_exclude = 0;
       config.PHAGE_EXCLUDE(phage_exclude);
-      Host * h = new Host(random, &w, &config, int_val);
+      emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
 
       THEN("syms are added without issue"){
         for(int i = 0; i < sym_limit; i++){
-          h->AddSymbiont(new Symbiont(random, &w, &config, int_val));
+          bacterium->AddSymbiont(emp::NewPtr<Phage>(random, &w, &config, int_val));
         }
-        int num_syms = (h->GetSymbionts()).size();
+        int num_syms = (bacterium->GetSymbionts()).size();
 
         REQUIRE(num_syms==sym_limit);
-        //with random seed 3 and phage exclusion on,
-        //num_syms not reach the sym_limit (would be 2 not 4)
+
+        bacterium.Delete();
       }
     }
 
@@ -230,15 +236,16 @@ TEST_CASE("Phage Exclude", "[lysis]") {
 
         for(int i = 0; i < 4; i ++){
           emp::Ptr<emp::Random> random = new emp::Random(i+1);
-          SymWorld w(*random);
+          LysisWorld w(*random);
 
-          Host * h = new Host(random, &w, &config, int_val);
+          emp::Ptr<Host> host = emp::NewPtr<Host>(random, &w, &config, int_val);
           for(double i = 0; i < 10; i++){
-            h->AddSymbiont(new Symbiont(random, &w, &config, int_val));
+            host->AddSymbiont(emp::NewPtr<Symbiont>(random, &w, &config, int_val));
           }
-          int host_num_syms = (h->GetSymbionts()).size();
+          int host_num_syms = (host->GetSymbionts()).size();
 
           REQUIRE(goal_num_syms[i] == host_num_syms);
+          host.Delete();
         }
       }
     }
@@ -251,17 +258,20 @@ TEST_CASE("Bacterium makeNew", "[lysis]"){
 
     double host_int_val = 0.2;
     double host_inc_val = 0.5;
-    Organism * h1 = new Bacterium(random, &w, &config, host_int_val);
-    h1->SetIncVal(host_inc_val);
-    Organism * h2 = h1->makeNew();
+    emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, host_int_val);
+    bacterium->SetIncVal(host_inc_val);
+    emp::Ptr<Organism> new_bacterium = bacterium->makeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
-      REQUIRE(h2->GetIntVal() == h1->GetIntVal());
-      REQUIRE(h2->GetIncVal() == h1->GetIncVal());
-      REQUIRE(h2->GetPoints() == 0);
-      REQUIRE(h2->GetAge() == 0);
+      REQUIRE(new_bacterium->GetIntVal() == bacterium->GetIntVal());
+      REQUIRE(new_bacterium->GetIncVal() == bacterium->GetIncVal());
+      REQUIRE(new_bacterium->GetPoints() == 0);
+      REQUIRE(new_bacterium->GetAge() == 0);
       //check that the offspring is the correct class
-      REQUIRE(typeid(*h2).name() == typeid(*h1).name());
+      REQUIRE(typeid(*new_bacterium).name() == typeid(*bacterium).name());
     }
+
+    bacterium.Delete();
+    new_bacterium.Delete();
 }
 
 TEST_CASE("Bacterium reproduce", "[lysis]"){
@@ -274,18 +284,21 @@ TEST_CASE("Bacterium reproduce", "[lysis]"){
 
     double host_int_val = -0.2;
     double host_inc_val = 0.3;
-    Organism * h1 = new Bacterium(random, &w, &config, host_int_val);
-    h1->SetIncVal(host_inc_val);
-    Organism * h2 = h1->reproduce();
+    emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, host_int_val);
+    bacterium->SetIncVal(host_inc_val);
+    emp::Ptr<Organism> bacterium_baby = bacterium->reproduce();
 
     THEN("The host baby has a mutated genome and has age and points of 0"){
-        REQUIRE(h2->GetIntVal() != h1->GetIntVal());
-        REQUIRE(h2->GetIncVal() != h1->GetIncVal());
-        REQUIRE(h2->GetAge() == 0);
-        REQUIRE(h2->GetPoints() == 0);
+        REQUIRE(bacterium_baby->GetIntVal() != bacterium->GetIntVal());
+        REQUIRE(bacterium_baby->GetIncVal() != bacterium->GetIncVal());
+        REQUIRE(bacterium_baby->GetAge() == 0);
+        REQUIRE(bacterium_baby->GetPoints() == 0);
     }
 
     THEN("The host parent's points are set to 0"){
-        REQUIRE(h1->GetPoints() == 0);
+        REQUIRE(bacterium->GetPoints() == 0);
     }
+
+    bacterium.Delete();
+    bacterium_baby.Delete();
 }

--- a/source/test/lysis_mode_test/Bacterium.test.cc
+++ b/source/test/lysis_mode_test/Bacterium.test.cc
@@ -55,8 +55,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_SIZE(0.002);
         config.MUTATION_RATE(1);
         config.MUTATE_INC_VAL(1);
-      //  emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
-        //working version:
+        
         emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
         bacterium->Mutate();
 

--- a/source/test/lysis_mode_test/Bacterium.test.cc
+++ b/source/test/lysis_mode_test/Bacterium.test.cc
@@ -58,7 +58,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
       //  emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
         //working version:
         emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
-        bacterium->mutate();
+        bacterium->Mutate();
 
         THEN("Then mutation occurs and the bacterium's host_inc_val mutates"){
             REQUIRE(bacterium->GetIncVal() != orig_host_inc_val);
@@ -74,7 +74,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_RATE(1);
         config.MUTATE_INC_VAL(0);
         emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
-        bacterium->mutate();
+        bacterium->Mutate();
 
         THEN("Then mutations occur but do not occur in the host_inc_val"){
             REQUIRE(bacterium->GetIncVal() ==  orig_host_inc_val);
@@ -88,7 +88,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_SIZE(0.0);
         config.MUTATE_INC_VAL(1);
         emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
-        bacterium->mutate();
+        bacterium->Mutate();
 
         THEN("Mutations do not occur"){
             REQUIRE(bacterium->GetIncVal() ==  orig_host_inc_val);
@@ -102,7 +102,7 @@ TEST_CASE("Bacterium mutate", "[lysis]"){
         config.MUTATION_SIZE(0.0);
         config.MUTATE_INC_VAL(0);
         emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, world, &config, int_val);
-        bacterium->mutate();
+        bacterium->Mutate();
 
         THEN("Mutations do not occur"){
             REQUIRE(bacterium->GetIncVal() ==  orig_host_inc_val);
@@ -251,7 +251,7 @@ TEST_CASE("Phage Exclude", "[lysis]") {
     }
 }
 
-TEST_CASE("Bacterium makeNew", "[lysis]"){
+TEST_CASE("Bacterium MakeNew", "[lysis]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     LysisWorld w(*random);
     SymConfigBase config;
@@ -260,7 +260,7 @@ TEST_CASE("Bacterium makeNew", "[lysis]"){
     double host_inc_val = 0.5;
     emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, host_int_val);
     bacterium->SetIncVal(host_inc_val);
-    emp::Ptr<Organism> new_bacterium = bacterium->makeNew();
+    emp::Ptr<Organism> new_bacterium = bacterium->MakeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
       REQUIRE(new_bacterium->GetIntVal() == bacterium->GetIntVal());
       REQUIRE(new_bacterium->GetIncVal() == bacterium->GetIncVal());
@@ -286,7 +286,7 @@ TEST_CASE("Bacterium reproduce", "[lysis]"){
     double host_inc_val = 0.3;
     emp::Ptr<Organism> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, host_int_val);
     bacterium->SetIncVal(host_inc_val);
-    emp::Ptr<Organism> bacterium_baby = bacterium->reproduce();
+    emp::Ptr<Organism> bacterium_baby = bacterium->Reproduce();
 
     THEN("The host baby has a mutated genome and has age and points of 0"){
         REQUIRE(bacterium_baby->GetIntVal() != bacterium->GetIntVal());

--- a/source/test/lysis_mode_test/BacteriumPhageUnitTest.test.cc
+++ b/source/test/lysis_mode_test/BacteriumPhageUnitTest.test.cc
@@ -259,8 +259,8 @@ TEST_CASE("Phage LysisBurst", "[lysis]"){
         world->AddOrgAt(orig_bacterium, 0);
         world->AddOrgAt(new_bacterium, 1);
 
-        emp::Ptr<Organism> p_baby1 = phage->reproduce();
-        emp::Ptr<Organism> p_baby2 = phage->reproduce();
+        emp::Ptr<Organism> p_baby1 = phage->Reproduce();
+        emp::Ptr<Organism> p_baby2 = phage->Reproduce();
         orig_bacterium->AddReproSym(p_baby1);
         orig_bacterium->AddReproSym(p_baby2);
 

--- a/source/test/lysis_mode_test/BacteriumPhageUnitTest.test.cc
+++ b/source/test/lysis_mode_test/BacteriumPhageUnitTest.test.cc
@@ -105,8 +105,8 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, sym_int_val);
             bacterium->AddSymbiont(phage);
 
             emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
@@ -116,6 +116,7 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             THEN ("Phage does not vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            bacterium.Delete();
             host_baby.Delete();
         }
         WHEN("Vertical Transmission is disabled"){
@@ -123,8 +124,8 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, sym_int_val);
             bacterium->AddSymbiont(phage);
 
             emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
@@ -134,6 +135,7 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             THEN ("Phage does not vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            bacterium.Delete();
             host_baby.Delete();
         }
 
@@ -147,8 +149,8 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, sym_int_val);
             bacterium->AddSymbiont(phage);
 
             emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
@@ -158,6 +160,7 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             THEN ("Phage does vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            bacterium.Delete();
             host_baby.Delete();
         }
          WHEN("Vertical Transmission is disabled"){
@@ -165,8 +168,8 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, sym_int_val);
             bacterium->AddSymbiont(phage);
 
             emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
@@ -176,13 +179,14 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             THEN ("Phage does vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            bacterium.Delete();
             host_baby.Delete();
         }
 
     }
 
 }
-/*
+
 TEST_CASE("Host phage death and removal from syms list", "[lysis]"){
     emp::Ptr<emp::Random> random = new emp::Random(6);
     LysisWorld w(*random);
@@ -327,4 +331,3 @@ TEST_CASE("Phage LysisStep", "[lysis]"){
 
     bacterium.Delete();
 }
-*/

--- a/source/test/lysis_mode_test/BacteriumPhageUnitTest.test.cc
+++ b/source/test/lysis_mode_test/BacteriumPhageUnitTest.test.cc
@@ -14,76 +14,76 @@ TEST_CASE("Phage Process", "[lysis]") {
         double int_val = -1;
 
         WHEN("Lysis is enabled and the Phage's burst timer >= the burst time") {
-            emp::Ptr<Phage> p;
-            p.New(random, world, &config, int_val);
-            emp::Ptr<Phage> p1;
-            p1.New(random, world, &config, int_val);
-            emp::Ptr<Phage> p2;
-            p2.New(random, world, &config, int_val);
+            emp::Ptr<Phage> phage;
+            phage.New(random, world, &config, int_val);
+            emp::Ptr<Phage> phage1;
+            phage1.New(random, world, &config, int_val);
+            emp::Ptr<Phage> phage2;
+            phage2.New(random, world, &config, int_val);
 
-            emp::Ptr<Bacterium> h;
-            h.New(random, &w, &config);
+            emp::Ptr<Bacterium> bacterium;
+            bacterium.New(random, &w, &config);
 
-            p->SetHost(h);
+            phage->SetHost(bacterium);
             int time = 15;
-            p->SetBurstTimer(time);
+            phage->SetBurstTimer(time);
 
-            h->AddReproSym(p1);
-            h->AddReproSym(p2);
+            bacterium->AddReproSym(phage1);
+            bacterium->AddReproSym(phage2);
 
             THEN("Lysis occurs, the host dies") {
                 size_t location = 2;
                 // double resources_per_host_per_update = 40;
 
-                p->Process(location);
+                phage->Process(location);
 
                 bool host_dead = true;
                 std::vector<emp::Ptr<Organism>> empty_syms = {};
-                REQUIRE(h->GetDead() == host_dead);
-                REQUIRE(h->GetReproSymbionts() == empty_syms);
+                REQUIRE(bacterium->GetDead() == host_dead);
+                REQUIRE(bacterium->GetReproSymbionts() == empty_syms);
             }
 
-            p.Delete();
-            h.Delete();
+            phage.Delete();
+            bacterium.Delete();
         }
 
         WHEN("Lysis is enabled and the Phage's burst timer < the burst time") {
-            emp::Ptr<Bacterium> h;
-            h.New(random, &w, &config);
+            emp::Ptr<Bacterium> bacterium;
+            bacterium.New(random, &w, &config);
 
             double phage_points = 10;
-            emp::Ptr<Phage> p3;
-            p3.New(random, world, &config, int_val);
-            emp::Ptr<Phage> p4;
-            p4.New(random, world, &config, int_val);
-            emp::Ptr<Phage> p5;
-            p5.New(random, world, &config, int_val);
-            p3->SetPoints(phage_points);
+            emp::Ptr<Phage> phage3;
+            phage3.New(random, world, &config, int_val);
+            emp::Ptr<Phage> phage4;
+            phage4.New(random, world, &config, int_val);
+            emp::Ptr<Phage> phage5;
+            phage5.New(random, world, &config, int_val);
+            phage3->SetPoints(phage_points);
 
-            h->AddReproSym(p4);
-            h->AddReproSym(p5);
+            bacterium->AddReproSym(phage4);
+            bacterium->AddReproSym(phage5);
             int num_host_orig_syms = 2;
-            p3->SetHost(h);
+            phage3->SetHost(bacterium);
 
             THEN("Phage reproduces, Host gains repro symbionts, Phage loses points") {
                 size_t location = 2;
                 // bool host_dead = false;
 
-                p3->Process(location);
+                phage3->Process(location);
 
-                REQUIRE(h->GetDead() == false);
+                REQUIRE(bacterium->GetDead() == false);
 
-                std::vector<emp::Ptr<Organism>> updated_repro_syms = h->GetReproSymbionts();
+                std::vector<emp::Ptr<Organism>> updated_repro_syms = bacterium->GetReproSymbionts();
 
                 REQUIRE( (int) updated_repro_syms.size() > num_host_orig_syms); // host gained repro syms
 
-                REQUIRE(p3->GetPoints() < phage_points); // phage lost points
+                REQUIRE(phage3->GetPoints() < phage_points); // phage lost points
 
 
             }
 
-            p3.Delete();
-            h.Delete();
+            phage3.Delete();
+            bacterium.Delete();
 
         }
         random.Delete();
@@ -105,34 +105,36 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> h = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> p = new Phage(random, world, &config, sym_int_val);
-            h->AddSymbiont(p);
+            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            bacterium->AddSymbiont(phage);
 
-            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, h->GetIntVal());
+            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
             long unsigned int expected_sym_size = host_baby->GetSymbionts().size();
-            p->VerticalTransmission(host_baby);
+            phage->VerticalTransmission(host_baby);
 
             THEN ("Phage does not vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            host_baby.Delete();
         }
-         WHEN("Vertical Transmission is disabled"){
+        WHEN("Vertical Transmission is disabled"){
             world->SetVertTrans(0);
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> h = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> p = new Phage(random, world, &config, sym_int_val);
-            h->AddSymbiont(p);
+            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            bacterium->AddSymbiont(phage);
 
-            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, h->GetIntVal());
+            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
             long unsigned int expected_sym_size = host_baby->GetSymbionts().size();
-            p->VerticalTransmission(host_baby);
+            phage->VerticalTransmission(host_baby);
 
             THEN ("Phage does not vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            host_baby.Delete();
         }
 
     }
@@ -145,40 +147,42 @@ TEST_CASE("Phage Vertical Transmission", "[lysis]"){
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> h = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> p = new Phage(random, world, &config, sym_int_val);
-            h->AddSymbiont(p);
+            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            bacterium->AddSymbiont(phage);
 
-            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, h->GetIntVal());
+            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
             long unsigned int expected_sym_size = host_baby->GetSymbionts().size() +1;
-            p->VerticalTransmission(host_baby);
+            phage->VerticalTransmission(host_baby);
 
             THEN ("Phage does vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            host_baby.Delete();
         }
          WHEN("Vertical Transmission is disabled"){
             world->SetVertTrans(0);
             double host_int_val = .5;
             double sym_int_val = -.5;
 
-            emp::Ptr<Bacterium> h = new Bacterium(random, world, &config, host_int_val);
-            emp::Ptr<Phage> p = new Phage(random, world, &config, sym_int_val);
-            h->AddSymbiont(p);
+            emp::Ptr<Bacterium> bacterium = new Bacterium(random, world, &config, host_int_val);
+            emp::Ptr<Phage> phage = new Phage(random, world, &config, sym_int_val);
+            bacterium->AddSymbiont(phage);
 
-            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, h->GetIntVal());
+            emp::Ptr<Bacterium> host_baby = emp::NewPtr<Bacterium>(random, world, &config, bacterium->GetIntVal());
             long unsigned int expected_sym_size = host_baby->GetSymbionts().size()+1;
-            p->VerticalTransmission(host_baby);
+            phage->VerticalTransmission(host_baby);
 
             THEN ("Phage does vertically transmit") {
                 REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
             }
+            host_baby.Delete();
         }
 
     }
 
 }
-
+/*
 TEST_CASE("Host phage death and removal from syms list", "[lysis]"){
     emp::Ptr<emp::Random> random = new emp::Random(6);
     LysisWorld w(*random);
@@ -191,18 +195,19 @@ TEST_CASE("Host phage death and removal from syms list", "[lysis]"){
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<Bacterium> h = new Bacterium(random, world, &config, host_int_val);
-        emp::Ptr<Phage> p = new Phage(random, world, &config, sym_int_val);
+        emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, host_int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, sym_int_val);
 
-        h->AddSymbiont(p);
-        p->SetDead();
+        bacterium->AddSymbiont(phage);
+        phage->SetDead();
 
         long unsigned int expected_sym_size = 0;
-        h->Process(0);
+        bacterium->Process(0);
 
         THEN("phage is removed from syms list"){
-            REQUIRE(h->GetSymbionts().size() == expected_sym_size);
+            REQUIRE(bacterium->GetSymbionts().size() == expected_sym_size);
         }
+        bacterium.Delete();
     }
 
     WHEN("There are multiple lysogenic phage and only one dies"){
@@ -210,24 +215,25 @@ TEST_CASE("Host phage death and removal from syms list", "[lysis]"){
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        Bacterium * h = new Bacterium(random, world, &config, host_int_val);
-        Phage * p1 = new Phage(random, world, &config, sym_int_val);
-        Phage * p2 = new Phage(random, world, &config, 0.0);
+        emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, world, &config, host_int_val);
+        emp::Ptr<Organism> phage1 = emp::NewPtr<Phage>(random, world, &config, sym_int_val);
+        emp::Ptr<Organism> phage2 = emp::NewPtr<Phage>(random, world, &config, 0.0);
 
-        h->AddSymbiont(p1);
-        h->AddSymbiont(p2);
-        p1->SetDead();
+        bacterium->AddSymbiont(phage1);
+        bacterium->AddSymbiont(phage2);
+        phage1->SetDead();
 
         long unsigned int expected_sym_size = 1;
-        h->Process(0);
+        bacterium->Process(0);
 
         THEN("Only the dead phage is removed from the syms list"){
-            REQUIRE(h->GetSymbionts().size() == expected_sym_size);
+            REQUIRE(bacterium->GetSymbionts().size() == expected_sym_size);
 
-            Organism * curSym = h->GetSymbionts()[0];
-            REQUIRE(curSym->GetIntVal() == p2->GetIntVal());
-            REQUIRE(curSym == p2);
+            emp::Ptr<Organism> curSym = bacterium->GetSymbionts()[0];
+            REQUIRE(curSym->GetIntVal() == phage2->GetIntVal());
+            REQUIRE(curSym == phage2);
         }
+        bacterium.Delete();
     }
 }
 
@@ -244,29 +250,29 @@ TEST_CASE("Phage LysisBurst", "[lysis]"){
     int location = 0;
 
     double int_val = 0;
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
     GIVEN("create two hosts and add both to world as neighbors, add phage offspring to the original host's repro syms"){
-        Bacterium * orig_h = new Bacterium(random, &w, &config, int_val);
-        Bacterium * new_h = new Bacterium(random, &w, &config, int_val);
-        orig_h->AddSymbiont(p);
-        world->AddOrgAt(orig_h, 0);
-        world->AddOrgAt(new_h, 1);
+        emp::Ptr<Bacterium> orig_bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+        emp::Ptr<Bacterium> new_bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+        orig_bacterium->AddSymbiont(phage);
+        world->AddOrgAt(orig_bacterium, 0);
+        world->AddOrgAt(new_bacterium, 1);
 
-        emp::Ptr<Organism> p_baby1 = p->reproduce();
-        emp::Ptr<Organism> p_baby2 = p->reproduce();
-        orig_h->AddReproSym(p_baby1);
-        orig_h->AddReproSym(p_baby2);
+        emp::Ptr<Organism> p_baby1 = phage->reproduce();
+        emp::Ptr<Organism> p_baby2 = phage->reproduce();
+        orig_bacterium->AddReproSym(p_baby1);
+        orig_bacterium->AddReproSym(p_baby2);
 
         WHEN("call the burst method so we can check injection") {
-            int original_sym_num = new_h->GetSymbionts().size() + orig_h->GetSymbionts().size();
-            p->LysisBurst(location);
+            int original_sym_num = new_bacterium->GetSymbionts().size() + orig_bacterium->GetSymbionts().size();
+            phage->LysisBurst(location);
 
             THEN("the repro syms go into the other host as symbionts and the original host dies"){
-                int new_sym_num = new_h->GetSymbionts().size() + orig_h->GetSymbionts().size();
+                int new_sym_num = new_bacterium->GetSymbionts().size() + orig_bacterium->GetSymbionts().size();
                 REQUIRE(new_sym_num == original_sym_num+2);
-                REQUIRE(size(orig_h->GetReproSymbionts()) == 0);
-                REQUIRE(orig_h->GetDead() == true);
+                REQUIRE(size(orig_bacterium->GetReproSymbionts()) == 0);
+                REQUIRE(orig_bacterium->GetDead() == true);
             }
         }
     }
@@ -283,39 +289,42 @@ TEST_CASE("Phage LysisStep", "[lysis]"){
     config.SYM_LYSIS_RES(sym_repro_points);
 
     double int_val = 0;
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-    Bacterium * h = new Bacterium(random, &w, &config, int_val);
-    h->AddSymbiont(p);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+    emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+    bacterium->AddSymbiont(phage);
 
     WHEN("The phage doesn't have enough resources to reproduce"){
-        double repro_syms_size_pre_process = size(h->GetReproSymbionts());
+        double repro_syms_size_pre_process = size(bacterium->GetReproSymbionts());
         double orig_points = 3.0;
         double expected_points = 3.0;
-        p->SetPoints(orig_points);
+        phage->SetPoints(orig_points);
         double orig_burst_time = 0.0;
-        p->SetBurstTimer(orig_burst_time);
+        phage->SetBurstTimer(orig_burst_time);
 
-        p->LysisStep();
+        phage->LysisStep();
         THEN("The burst timer is incremented but no offspring are created"){
-            REQUIRE(p->GetBurstTimer() > orig_burst_time);
-            REQUIRE(size(h->GetReproSymbionts()) == repro_syms_size_pre_process);
-            REQUIRE(p->GetPoints() == expected_points);
+            REQUIRE(phage->GetBurstTimer() > orig_burst_time);
+            REQUIRE(size(bacterium->GetReproSymbionts()) == repro_syms_size_pre_process);
+            REQUIRE(phage->GetPoints() == expected_points);
         }
     }
 
     WHEN("The phage does have enough resources to reproduce"){
-        double expected_repro_syms_size_post_process = size(h->GetReproSymbionts()) + 1; //one offspring created
+        double expected_repro_syms_size_post_process = size(bacterium->GetReproSymbionts()) + 1; //one offspring created
         double orig_points = sym_repro_points;//symbiont given enough resources to produce one offspring
         double expected_points = 0.0;
-        p->SetPoints(orig_points);
+        phage->SetPoints(orig_points);
         double orig_burst_time = 0.0;
-        p->SetBurstTimer(orig_burst_time);
+        phage->SetBurstTimer(orig_burst_time);
 
-        p->LysisStep();
+        phage->LysisStep();
         THEN("The burst timer is incremented and offspring are created"){
-            REQUIRE(p->GetBurstTimer() > orig_burst_time);
-            REQUIRE(size(h->GetReproSymbionts()) == expected_repro_syms_size_post_process);
-            REQUIRE(p->GetPoints() == expected_points);
+            REQUIRE(phage->GetBurstTimer() > orig_burst_time);
+            REQUIRE(size(bacterium->GetReproSymbionts()) == expected_repro_syms_size_post_process);
+            REQUIRE(phage->GetPoints() == expected_points);
         }
     }
+
+    bacterium.Delete();
 }
+*/

--- a/source/test/lysis_mode_test/LysisDataNodes.test.cc
+++ b/source/test/lysis_mode_test/LysisDataNodes.test.cc
@@ -21,7 +21,7 @@ TEST_CASE("GetCFUDataNode", "[lysis]"){
       size_t num_hosts = 10;
 
       for(size_t i = 0; i < num_hosts; i++){
-        w.AddOrgAt(new Bacterium(&random, &w, &config, int_val), i);
+        w.AddOrgAt(emp::NewPtr<Bacterium>(&random, &w, &config, int_val), i);
       }
 
       w.Update();
@@ -33,9 +33,9 @@ TEST_CASE("GetCFUDataNode", "[lysis]"){
       WHEN("some hosts are infected with lytic phage"){
         size_t num_infections = 2;
         for(size_t i = 0; i < num_infections; i++){
-          Phage *p = new Phage(&random, &w, &config, int_val);
-          p->SetLysisChance(1.0);
-          w.GetOrg(i).AddSymbiont(p);
+          emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
+          phage->SetLysisChance(1.0);
+          w.GetOrg(i).AddSymbiont(phage);
         }
         w.Update();
         THEN("infected hosts are excluded from the cfu count"){
@@ -47,9 +47,9 @@ TEST_CASE("GetCFUDataNode", "[lysis]"){
       WHEN("hosts are infected with lysogenic phage"){
         size_t num_infections = 2;
         for(size_t i = 0; i < num_infections; i++){
-          Phage *p = new Phage(&random, &w, &config, int_val);
-          p->SetLysisChance(0.0);
-          w.GetOrg(i).AddSymbiont(p);
+          emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
+          phage->SetLysisChance(0.0);
+          w.GetOrg(i).AddSymbiont(phage);
         }
         w.Update();
         THEN("infected hosts are excluded from the cfu count"){
@@ -90,14 +90,14 @@ TEST_CASE("GetLysisChanceDataNode", "[lysis]"){
       expected_hist_counts[8] = 1;
       expected_hist_counts[9] = 1;
 
-      Bacterium *bacterium = new Bacterium(&random, &w, &config, int_val);
+      emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
       w.AddOrgAt(bacterium, 0);
       for(size_t i = 0; i < 3; i++){
-        Phage *free_phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Phage> free_phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         free_phage->SetLysisChance(free_phage_lysis_chances[i]);
         w.AddOrgAt(free_phage, emp::WorldPosition(0,i));
 
-        Phage *hosted_phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Phage> hosted_phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         hosted_phage->SetLysisChance(hosted_phage_lysis_chances[i]);
         bacterium->AddSymbiont(hosted_phage);
       }
@@ -146,14 +146,14 @@ TEST_CASE("GetInductionChanceDataNode", "[lysis]"){
       expected_hist_counts[8] = 1;
       expected_hist_counts[9] = 1;
 
-      Bacterium *bacterium = new Bacterium(&random, &w, &config, int_val);
+      emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
       w.AddOrgAt(bacterium, 0);
       for(size_t i = 0; i < 3; i++){
-        Phage *free_phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Phage> free_phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         free_phage->SetInductionChance(free_phage_induction_chances[i]);
         w.AddOrgAt(free_phage, emp::WorldPosition(0,i));
 
-        Phage *hosted_phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Phage> hosted_phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         hosted_phage->SetInductionChance(hosted_phage_induction_chances[i]);
         bacterium->AddSymbiont(hosted_phage);
       }
@@ -194,15 +194,15 @@ TEST_CASE("GetBurstSizeDataNode", "[lysis]"){
       double expected_av = 5.5;
       for(int i = 0; i < 4; i++){ // populate world with 4 bacteria
         //each of which has a different burst size
-        Bacterium *h = new Bacterium(&random, &w, &config, int_val);
-        Phage *p = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         for(size_t j = 0; j < burst_sizes[i]; j++) {
-          Organism *new_repro_phage = p->reproduce();
-          h->AddReproSym(new_repro_phage);
+          emp::Ptr<Organism> new_repro_phage = phage->reproduce();
+          bacterium->AddReproSym(new_repro_phage);
         }
-        p->SetBurstTimer(burst_time);
-        h->AddSymbiont(p);
-        w.AddOrgAt(h, i);
+        phage->SetBurstTimer(burst_time);
+        bacterium->AddSymbiont(phage);
+        w.AddOrgAt(bacterium, i);
       }
       w.Update();
 
@@ -233,14 +233,14 @@ TEST_CASE("GetBurstCountDataNode", "[lysis]"){
     WHEN("bacteria lyse"){
       int expected_total = 2;
       for(int i = 0; i < 4; i++){ // populate world with 4 bacteria
-        Bacterium *bacterium = new Bacterium(&random, &w, &config, int_val);
-        Phage *phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         if(i < 2){ //ensure two of the bacteria will lyse
           phage->SetBurstTimer(burst_time);
         }
         bacterium->AddSymbiont(phage);
 
-        Organism *new_repro_phage = phage->reproduce();
+        emp::Ptr<Organism> new_repro_phage = phage->reproduce();
         bacterium->AddReproSym(new_repro_phage);
 
         w.AddOrgAt(bacterium, i);
@@ -279,22 +279,22 @@ TEST_CASE("GetIncorporationDifferenceDataNode", "[lysis]"){
 
     WHEN("hosted symbionts exist"){
       // no inc val difference
-      Bacterium *bacterium = new Bacterium(&random, &w, &config, int_val);
+      emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
       bacterium->SetIncVal(0);
       w.AddOrgAt(bacterium, 0);
       for(size_t j = 0; j < 3; j++){
-        Phage *phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         phage->SetIncVal(0);
         bacterium->AddSymbiont(phage);
       }
 
       // inc val differences of 0.36, 0.15, 0.15
       double sym_inc_vals[3] = {0.14, 0.35, 0.65};
-      bacterium = new Bacterium(&random, &w, &config, int_val);
+      bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
       bacterium->SetIncVal(0.5);
       w.AddOrgAt(bacterium, 1);
       for(size_t j = 0; j < 3; j++){
-        Phage *phage = new Phage(&random, &w, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         phage->SetIncVal(sym_inc_vals[j]);
         bacterium->AddSymbiont(phage);
       }

--- a/source/test/lysis_mode_test/LysisDataNodes.test.cc
+++ b/source/test/lysis_mode_test/LysisDataNodes.test.cc
@@ -197,7 +197,7 @@ TEST_CASE("GetBurstSizeDataNode", "[lysis]"){
         emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(&random, &w, &config, int_val);
         emp::Ptr<Phage> phage = emp::NewPtr<Phage>(&random, &w, &config, int_val);
         for(size_t j = 0; j < burst_sizes[i]; j++) {
-          emp::Ptr<Organism> new_repro_phage = phage->reproduce();
+          emp::Ptr<Organism> new_repro_phage = phage->Reproduce();
           bacterium->AddReproSym(new_repro_phage);
         }
         phage->SetBurstTimer(burst_time);
@@ -240,7 +240,7 @@ TEST_CASE("GetBurstCountDataNode", "[lysis]"){
         }
         bacterium->AddSymbiont(phage);
 
-        emp::Ptr<Organism> new_repro_phage = phage->reproduce();
+        emp::Ptr<Organism> new_repro_phage = phage->Reproduce();
         bacterium->AddReproSym(new_repro_phage);
 
         w.AddOrgAt(bacterium, i);

--- a/source/test/lysis_mode_test/Phage.test.cc
+++ b/source/test/lysis_mode_test/Phage.test.cc
@@ -140,7 +140,7 @@ TEST_CASE("Phage reproduce", "[lysis]") {
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
         emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
-        emp::Ptr<Organism> phage_baby = phage->reproduce();
+        emp::Ptr<Organism> phage_baby = phage->Reproduce();
 
         THEN("Offspring's interaction value and lysis chance equals parent's interaction value and lysis chance") {
             int phage_baby_int_val = 0;
@@ -169,7 +169,7 @@ TEST_CASE("Phage reproduce", "[lysis]") {
         config.MUTATION_RATE(1);
         config.MUTATION_SIZE(0.002);
         emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
-        emp::Ptr<Organism> phage_baby = phage->reproduce();
+        emp::Ptr<Organism> phage_baby = phage->Reproduce();
 
         THEN("Offspring's interaction value and lysis chance does not equal parent's interaction value and lysis chance") {
             REQUIRE( phage_baby->GetIntVal() != parent_orig_int_val);
@@ -284,13 +284,13 @@ TEST_CASE("Phage uponInjection", "[lysis]"){
     REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
     //phage should choose lysis by default
-    phage->uponInjection();
+    phage->UponInjection();
     expected_lysogeny = false;
     REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
     //if chance of lysis is 0, phage should choose lysogeny
     phage->SetLysisChance(0.0);
-    phage->uponInjection();
+    phage->UponInjection();
     expected_lysogeny = true;
     REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
@@ -314,7 +314,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_INC_VAL(1);
 
         emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
-        phage->mutate();
+        phage->Mutate();
         THEN("Mutation occurs and chance of lysis changes") {
             REQUIRE(phage->GetLysisChance() != 0.5);
             REQUIRE(phage->GetLysisChance() >= 0.5 - 0.002*3);
@@ -336,7 +336,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_INDUCTION_CHANCE(0);
         config.MUTATE_INC_VAL(0);
         emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
-        phage->mutate();
+        phage->Mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
         double incorporation_val_post_mutation = 0.5;
@@ -356,7 +356,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_INDUCTION_CHANCE(1);
         config.MUTATE_INC_VAL(1);
         emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
-        phage->mutate();
+        phage->Mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
         double incorporation_val_post_mutation = 0.5;
@@ -376,7 +376,7 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_INDUCTION_CHANCE(0);
         config.MUTATE_INC_VAL(0);
         emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
-        phage->mutate();
+        phage->Mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
         double incorporation_val_post_mutation = 0.5;
@@ -505,8 +505,8 @@ TEST_CASE("Phage process", "[lysis]"){
             world->AddOrgAt(new_bacterium, 1);
 
             //add phage offspring to the original host's repro syms
-            emp::Ptr<Organism> p_baby1 = phage->reproduce();
-            emp::Ptr<Organism> p_baby2 = phage->reproduce();
+            emp::Ptr<Organism> p_baby1 = phage->Reproduce();
+            emp::Ptr<Organism> p_baby2 = phage->Reproduce();
             orig_bacterium->AddReproSym(p_baby1);
             orig_bacterium->AddReproSym(p_baby2);
 
@@ -586,7 +586,7 @@ TEST_CASE("Phage ProcessResources", "[lysis]"){
             emp::Ptr<Bacterium> bacterium;
             bacterium.New(random, world, &config, int_val);
             bacterium->AddSymbiont(phage);
-            phage->uponInjection();
+            phage->UponInjection();
 
             double sym_piece = 40;
             double expected_return = 0;
@@ -664,14 +664,14 @@ TEST_CASE("Phage ProcessResources", "[lysis]"){
     }
 }
 
-TEST_CASE("Phage makeNew", "[lysis]"){
+TEST_CASE("Phage MakeNew", "[lysis]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     LysisWorld w(*random);
     SymConfigBase config;
 
     double phage_int_val = 0.2;
     emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, &w, &config, phage_int_val);
-    emp::Ptr<Organism> new_phage = phage->makeNew();
+    emp::Ptr<Organism> new_phage = phage->MakeNew();
 
     THEN("The new phage has the same genome as its parent, but age and points 0"){
         REQUIRE(new_phage->GetIntVal() == phage->GetIntVal());

--- a/source/test/lysis_mode_test/Phage.test.cc
+++ b/source/test/lysis_mode_test/Phage.test.cc
@@ -1,4 +1,5 @@
 #include "../../lysis_mode/Phage.h"
+#include "../../lysis_mode/Bacterium.h"
 
 TEST_CASE("Phage constructor, GetIntVal", "[lysis]") {
     emp::Ptr<emp::Random> random = new emp::Random(27);
@@ -8,119 +9,119 @@ TEST_CASE("Phage constructor, GetIntVal", "[lysis]") {
 
     WHEN("Int val is passed in as negative"){
         double int_val = -1;
-        Phage * p = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
         double expected_int_val = -1;
         THEN("Int val is set to be negative"){
-            REQUIRE(p->GetIntVal() == expected_int_val);
-            REQUIRE(p->GetAge() == 0); 
-            REQUIRE(p->GetPoints() == 0);
-            REQUIRE(p->GetBurstTimer() == 0);
+            REQUIRE(phage->GetIntVal() == expected_int_val);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p;
+        phage.Delete();
     }
 
     WHEN("Int val is passed in as zero"){
         double int_val = 0;
-        Phage * p2 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
         double expected_int_val = 0;
 
         THEN("Int val is set to be zero"){
-            REQUIRE(p2->GetIntVal() == expected_int_val);
-            REQUIRE(p2->GetAge() == 0); 
-            REQUIRE(p2->GetPoints() == 0);
-            REQUIRE(p2->GetBurstTimer() == 0);
+            REQUIRE(phage->GetIntVal() == expected_int_val);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p2;
+        phage.Delete();
     }
 
     WHEN("Lysis chance is random"){
         double int_val = 0;
         config.LYSIS_CHANCE(-1);
-        Phage * p3 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
         THEN("Lysis chance is randomly between 0 and 1"){
-            REQUIRE(p3->GetLysisChance() >= 0);
-            REQUIRE(p3->GetLysisChance() <= 1);
-            REQUIRE(p3->GetAge() == 0); 
-            REQUIRE(p3->GetPoints() == 0);
-            REQUIRE(p3->GetBurstTimer() == 0);
+            REQUIRE(phage->GetLysisChance() >= 0);
+            REQUIRE(phage->GetLysisChance() <= 1);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p3;
+        phage.Delete();
     }
 
     WHEN("Lysis chance is not random"){
         double int_val = 0;
         config.LYSIS_CHANCE(.5);
-        Phage * p4 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
         double expected_lysis_chance = 0.5;
 
         THEN("Lysis chance is set to what was passed in"){
-            REQUIRE(p4->GetLysisChance() == expected_lysis_chance);
-            REQUIRE(p4->GetAge() == 0); 
-            REQUIRE(p4->GetPoints() == 0);
-            REQUIRE(p4->GetBurstTimer() == 0);
+            REQUIRE(phage->GetLysisChance() == expected_lysis_chance);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p4;
+        phage.Delete();
     }
 
     WHEN("Chance of induction is random"){
         double int_val = 0;
         config.CHANCE_OF_INDUCTION(-1);
-        Phage * p5 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
         THEN("Chance of induction is randomly between 0 and 1"){
-            REQUIRE(p5->GetInductionChance() >= 0);
-            REQUIRE(p5->GetInductionChance() <= 1);
-            REQUIRE(p5->GetAge() == 0); 
-            REQUIRE(p5->GetPoints() == 0);
-            REQUIRE(p5->GetBurstTimer() == 0);
+            REQUIRE(phage->GetInductionChance() >= 0);
+            REQUIRE(phage->GetInductionChance() <= 1);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p5;
+        phage.Delete();
     }
 
     WHEN("Chance of induction is not random"){
         double int_val = 0;
         config.CHANCE_OF_INDUCTION(0.2);
-        Phage * p6 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
         double expected_induction_chance = 0.2;
 
         THEN("Chance of induction is set to what was passed in"){
-            REQUIRE(p6->GetInductionChance() == expected_induction_chance);
-            REQUIRE(p6->GetAge() == 0); 
-            REQUIRE(p6->GetPoints() == 0);
-            REQUIRE(p6->GetBurstTimer() == 0);
+            REQUIRE(phage->GetInductionChance() == expected_induction_chance);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p6;
+        phage.Delete();
     }
 
     WHEN("Incorporation val is random"){
         double int_val = 0;
         config.PHAGE_INC_VAL(-1);
-        Phage * p7 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
         THEN("Incorporation val is randomly between 0 and 1"){
-            REQUIRE(p7->GetIncVal() >= 0);
-            REQUIRE(p7->GetIncVal() <= 1);
-            REQUIRE(p7->GetAge() == 0); 
-            REQUIRE(p7->GetPoints() == 0);
-            REQUIRE(p7->GetBurstTimer() == 0);
+            REQUIRE(phage->GetIncVal() >= 0);
+            REQUIRE(phage->GetIncVal() <= 1);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p7;
+        phage.Delete();
     }
 
     WHEN("Incorporation val is not random"){
         double int_val = 0;
         config.PHAGE_INC_VAL(0.3);
-        Phage * p8 = new Phage(random, world, &config, int_val);
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
         double expected_incorporation_value = 0.3;
 
         THEN("Incorporation val is set to what was passed in"){
-            REQUIRE(p8->GetIncVal() == expected_incorporation_value);
-            REQUIRE(p8->GetAge() == 0); 
-            REQUIRE(p8->GetPoints() == 0);
-            REQUIRE(p8->GetBurstTimer() == 0);
+            REQUIRE(phage->GetIncVal() == expected_incorporation_value);
+            REQUIRE(phage->GetAge() == 0);
+            REQUIRE(phage->GetPoints() == 0);
+            REQUIRE(phage->GetBurstTimer() == 0);
         }
-        delete p8;
+        phage.Delete();
     }
 }
 
@@ -138,19 +139,19 @@ TEST_CASE("Phage reproduce", "[lysis]") {
         double parent_orig_lysis_chance=.5;
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
-        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-        emp::Ptr<Organism> phage_baby = p->reproduce();
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+        emp::Ptr<Organism> phage_baby = phage->reproduce();
 
         THEN("Offspring's interaction value and lysis chance equals parent's interaction value and lysis chance") {
             int phage_baby_int_val = 0;
             REQUIRE( phage_baby->GetIntVal() == phage_baby_int_val);
             REQUIRE( phage_baby->GetIntVal() == parent_orig_int_val);
-            REQUIRE( p->GetIntVal() == parent_orig_int_val);
+            REQUIRE( phage->GetIntVal() == parent_orig_int_val);
 
             double phage_baby_lysis_chance = .5;
             REQUIRE( phage_baby->GetLysisChance() == phage_baby_lysis_chance);
             REQUIRE( phage_baby->GetLysisChance() == parent_orig_lysis_chance);
-            REQUIRE( p->GetLysisChance() == parent_orig_lysis_chance);
+            REQUIRE( phage->GetLysisChance() == parent_orig_lysis_chance);
         }
         THEN("Offspring's points and burst timer are zero") {
             int phage_baby_points = 0;
@@ -158,8 +159,8 @@ TEST_CASE("Phage reproduce", "[lysis]") {
             REQUIRE( phage_baby->GetPoints() == phage_baby_points);
             REQUIRE(phage_baby->GetBurstTimer() == phage_baby_burst_timer);
         }
-        delete p;
-        delete phage_baby;
+        phage.Delete();
+        phage_baby.Delete();
     }
     WHEN("Mutation rate is not zero") {
         double int_val = 0;
@@ -167,8 +168,8 @@ TEST_CASE("Phage reproduce", "[lysis]") {
         double parent_orig_lysis_chance=.5;
         config.MUTATION_RATE(1);
         config.MUTATION_SIZE(0.002);
-        emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-        emp::Ptr<Organism> phage_baby = p->reproduce();
+        emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+        emp::Ptr<Organism> phage_baby = phage->reproduce();
 
         THEN("Offspring's interaction value and lysis chance does not equal parent's interaction value and lysis chance") {
             REQUIRE( phage_baby->GetIntVal() != parent_orig_int_val);
@@ -186,8 +187,8 @@ TEST_CASE("Phage reproduce", "[lysis]") {
             int phage_baby_burst_timer = 0;
             REQUIRE( phage_baby->GetBurstTimer() == phage_baby_burst_timer);
         }
-        delete p;
-        delete phage_baby;
+        phage.Delete();
+        phage_baby.Delete();
     }
 }
 
@@ -197,27 +198,28 @@ TEST_CASE("SetBurstTimer, IncBurstTimer", "[lysis]"){
     LysisWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
     int default_burst_time = 0;
-    REQUIRE(p->GetBurstTimer() == default_burst_time);
+    REQUIRE(phage->GetBurstTimer() == default_burst_time);
 
-    p->IncBurstTimer();
-    REQUIRE(p->GetBurstTimer() != default_burst_time);
-    REQUIRE(p->GetBurstTimer() <= default_burst_time + 1*3);
-    REQUIRE(p->GetBurstTimer() >= default_burst_time - 1*3);
+    phage->IncBurstTimer();
+    REQUIRE(phage->GetBurstTimer() != default_burst_time);
+    REQUIRE(phage->GetBurstTimer() <= default_burst_time + 1*3);
+    REQUIRE(phage->GetBurstTimer() >= default_burst_time - 1*3);
 
     int burst_time = 15;
-    p->SetBurstTimer(burst_time);
+    phage->SetBurstTimer(burst_time);
 
     int expected_burst_time = 15;
-    REQUIRE(p->GetBurstTimer() == expected_burst_time);
+    REQUIRE(phage->GetBurstTimer() == expected_burst_time);
 
-    p->IncBurstTimer();
-    REQUIRE(p->GetBurstTimer() <= expected_burst_time + 1*3);
-    REQUIRE(p->GetBurstTimer() >= expected_burst_time - 1*3);
-    REQUIRE(p->GetBurstTimer() != expected_burst_time);
+    phage->IncBurstTimer();
+    REQUIRE(phage->GetBurstTimer() <= expected_burst_time + 1*3);
+    REQUIRE(phage->GetBurstTimer() >= expected_burst_time - 1*3);
+    REQUIRE(phage->GetBurstTimer() != expected_burst_time);
 
+    phage.Delete();
 }
 
 TEST_CASE("Phage SetLysisChance, GetLysisChance", "[lysis]"){
@@ -226,14 +228,14 @@ TEST_CASE("Phage SetLysisChance, GetLysisChance", "[lysis]"){
     LysisWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
     double lysis_chance = 0.5;
-    p->SetLysisChance(lysis_chance);
+    phage->SetLysisChance(lysis_chance);
     double expected_lysis_chance = 0.5;
-    REQUIRE(p->GetLysisChance() == expected_lysis_chance);
+    REQUIRE(phage->GetLysisChance() == expected_lysis_chance);
 
-    delete p;
+    phage.Delete();
 }
 
 TEST_CASE("Phage SetInductionChance, GetInductionChance", "[lysis]"){
@@ -242,14 +244,14 @@ TEST_CASE("Phage SetInductionChance, GetInductionChance", "[lysis]"){
     LysisWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
     double induction_chance = 0.5;
-    p->SetInductionChance(induction_chance);
+    phage->SetInductionChance(induction_chance);
     double expected_induction_chance = 0.5;
-    REQUIRE(p->GetInductionChance() == expected_induction_chance);
+    REQUIRE(phage->GetInductionChance() == expected_induction_chance);
 
-    delete p;
+    phage.Delete();
 }
 
 TEST_CASE("Phage SetIncVal, GetIncVal", "[lysis]"){
@@ -258,14 +260,14 @@ TEST_CASE("Phage SetIncVal, GetIncVal", "[lysis]"){
     LysisWorld * world = &w;
     SymConfigBase config;
     double int_val = -1;
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
     double incorporation_val = 0.5;
-    p->SetIncVal(incorporation_val);
+    phage->SetIncVal(incorporation_val);
     double expected_incorporation_value = 0.5;
-    REQUIRE(p->GetIncVal() == expected_incorporation_value);
+    REQUIRE(phage->GetIncVal() == expected_incorporation_value);
 
-    delete p;
+    phage.Delete();
 }
 
 TEST_CASE("Phage uponInjection", "[lysis]"){
@@ -275,24 +277,24 @@ TEST_CASE("Phage uponInjection", "[lysis]"){
     SymConfigBase config;
     double int_val = -1;
     config.LYSIS_CHANCE(1);
-    emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+    emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
     //initialization of phage sets lysogeny to false
     bool expected_lysogeny = false;
-    REQUIRE(p->GetLysogeny() == expected_lysogeny);
+    REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
     //phage should choose lysis by default
-    p->uponInjection();
+    phage->uponInjection();
     expected_lysogeny = false;
-    REQUIRE(p->GetLysogeny() == expected_lysogeny);
+    REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
     //if chance of lysis is 0, phage should choose lysogeny
-    p->SetLysisChance(0.0);
-    p->uponInjection();
+    phage->SetLysisChance(0.0);
+    phage->uponInjection();
     expected_lysogeny = true;
-    REQUIRE(p->GetLysogeny() == expected_lysogeny);
+    REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
-    delete p;
+    phage.Delete();
 }
 
 TEST_CASE("phage_mutate", "[lysis]"){
@@ -311,20 +313,20 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_INDUCTION_CHANCE(1);
         config.MUTATE_INC_VAL(1);
 
-        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
-        p->mutate();
+        emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+        phage->mutate();
         THEN("Mutation occurs and chance of lysis changes") {
-            REQUIRE(p->GetLysisChance() != 0.5);
-            REQUIRE(p->GetLysisChance() >= 0.5 - 0.002*3);
-            REQUIRE(p->GetLysisChance() <= 0.5 + 0.002*3);
-            REQUIRE(p->GetInductionChance() != 0.5);
-            REQUIRE(p->GetInductionChance() >= 0.5 - 0.002*3);
-            REQUIRE(p->GetInductionChance() <= 0.5 + 0.002*3);
-            REQUIRE(p->GetIncVal() != 0.5);
-            REQUIRE(p->GetIncVal() >= 0.5 - 0.002*3);
-            REQUIRE(p->GetIncVal() <= 0.5 + 0.002*3);
+            REQUIRE(phage->GetLysisChance() != 0.5);
+            REQUIRE(phage->GetLysisChance() >= 0.5 - 0.002*3);
+            REQUIRE(phage->GetLysisChance() <= 0.5 + 0.002*3);
+            REQUIRE(phage->GetInductionChance() != 0.5);
+            REQUIRE(phage->GetInductionChance() >= 0.5 - 0.002*3);
+            REQUIRE(phage->GetInductionChance() <= 0.5 + 0.002*3);
+            REQUIRE(phage->GetIncVal() != 0.5);
+            REQUIRE(phage->GetIncVal() >= 0.5 - 0.002*3);
+            REQUIRE(phage->GetIncVal() <= 0.5 + 0.002*3);
         }
-        delete p;
+        phage.Delete();
     }
 
     WHEN("Mutation rate is not zero and chance of lysis/induction mutations are not enabled"){
@@ -333,17 +335,17 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_LYSIS_CHANCE(0);
         config.MUTATE_INDUCTION_CHANCE(0);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
-        p->mutate();
+        emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+        phage->mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
         double incorporation_val_post_mutation = 0.5;
         THEN("Mutation does not occur and chance of lysis/chance of induction does not change") {
-            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-            REQUIRE(p->GetInductionChance() == Approx(induction_chance_post_mutation));
-            REQUIRE(p->GetIncVal() == Approx(incorporation_val_post_mutation));
+            REQUIRE(phage->GetLysisChance() == Approx(lysis_chance_post_mutation));
+            REQUIRE(phage->GetInductionChance() == Approx(induction_chance_post_mutation));
+            REQUIRE(phage->GetIncVal() == Approx(incorporation_val_post_mutation));
         }
-        delete p;
+        phage.Delete();
     }
 
     WHEN("Mutation rate is zero and chance of lysis/chance of induction mutations are enabled"){
@@ -353,17 +355,17 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_LYSIS_CHANCE(1);
         config.MUTATE_INDUCTION_CHANCE(1);
         config.MUTATE_INC_VAL(1);
-        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
-        p->mutate();
+        emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+        phage->mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
         double incorporation_val_post_mutation = 0.5;
         THEN("Mutation does not occur and chance of lysis/chance of induction does not change") {
-            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-            REQUIRE(p->GetInductionChance() == Approx(induction_chance_post_mutation));
-            REQUIRE(p->GetIncVal() == Approx(incorporation_val_post_mutation));
+            REQUIRE(phage->GetLysisChance() == Approx(lysis_chance_post_mutation));
+            REQUIRE(phage->GetInductionChance() == Approx(induction_chance_post_mutation));
+            REQUIRE(phage->GetIncVal() == Approx(incorporation_val_post_mutation));
         }
-        delete p;
+        phage.Delete();
     }
 
     WHEN("Mutation rate is zero and chance of lysis mutations are not enabled and chance of induction mutations are not enabled"){
@@ -373,17 +375,17 @@ TEST_CASE("phage_mutate", "[lysis]"){
         config.MUTATE_LYSIS_CHANCE(0);
         config.MUTATE_INDUCTION_CHANCE(0);
         config.MUTATE_INC_VAL(0);
-        emp::Ptr<Organism> p = new Phage(random, world, &config, int_val);
-        p->mutate();
+        emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+        phage->mutate();
         double lysis_chance_post_mutation = 0.5;
         double induction_chance_post_mutation = 0.5;
         double incorporation_val_post_mutation = 0.5;
         THEN("Mutation does not occur and chance of lysis/chance of induction does not change") {
-            REQUIRE(p->GetLysisChance() == Approx(lysis_chance_post_mutation));
-            REQUIRE(p->GetInductionChance() == Approx(induction_chance_post_mutation));
-            REQUIRE(p->GetIncVal() == Approx(incorporation_val_post_mutation));
+            REQUIRE(phage->GetLysisChance() == Approx(lysis_chance_post_mutation));
+            REQUIRE(phage->GetInductionChance() == Approx(induction_chance_post_mutation));
+            REQUIRE(phage->GetIncVal() == Approx(incorporation_val_post_mutation));
         }
-        delete p;
+        phage.Delete();
     }
 }
 
@@ -406,23 +408,24 @@ TEST_CASE("Phage process", "[lysis]"){
             config.CHANCE_OF_INDUCTION(1);
 
             double int_val = 0;
-            emp::Ptr<Phage> p;
-            p.New(random, world, &config, int_val);
+            emp::Ptr<Phage> phage;
+            phage.New(random, world, &config, int_val);
 
-            emp::Ptr<Bacterium> h;
-            h.New(random, &w, &config, int_val);
+            emp::Ptr<Bacterium> bacterium;
+            bacterium.New(random, &w, &config, int_val);
 
             //verify that the phage chooses lysogeny first
             bool expected_lysogeny = true;
-            h->AddSymbiont(p);
-            REQUIRE(p->GetLysogeny() == expected_lysogeny);
+            bacterium->AddSymbiont(phage);
+            REQUIRE(phage->GetLysogeny() == expected_lysogeny);
 
             expected_lysogeny = false;
-            p->Process(location);
+            phage->Process(location);
 
             THEN("The phage turns lytic"){
-                REQUIRE(p->GetLysogeny() == expected_lysogeny);
+                REQUIRE(phage->GetLysogeny() == expected_lysogeny);
             }
+            bacterium.Delete();
         }
 
         WHEN("The phage does not induce"){
@@ -432,53 +435,53 @@ TEST_CASE("Phage process", "[lysis]"){
                 config.PROPHAGE_LOSS_RATE(1);
 
                 double int_val = 0;
-                emp::Ptr<Phage> p;
-                p.New(random, world, &config, int_val);
+                emp::Ptr<Phage> phage;
+                phage.New(random, world, &config, int_val);
 
-                emp::Ptr<Bacterium> h;
-                h.New(random, &w, &config, int_val);
+                emp::Ptr<Bacterium> bacterium;
+                bacterium.New(random, &w, &config, int_val);
 
-                h->AddSymbiont(p);
+                bacterium->AddSymbiont(phage);
 
                 bool expected_dead = true;
 
-                p->Process(location);
+                phage->Process(location);
 
                 THEN("The phage dies"){
-                    REQUIRE(p->GetDead() == expected_dead);
+                    REQUIRE(phage->GetDead() == expected_dead);
                 }
-                h.Delete();
+                bacterium.Delete();
             }
 
             WHEN("The prophage loss rate is 0"){
                 config.PROPHAGE_LOSS_RATE(0);
                 double int_val = 0;
                 double expected_int_val = 0;
-                emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-                Bacterium * h = new Bacterium(random, &w, &config, int_val);
-                h->AddSymbiont(p);
+                emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+                emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+                bacterium->AddSymbiont(phage);
 
                 double points = 0;
                 double expected_points = 0;
-                p->SetPoints(points);
+                phage->SetPoints(points);
 
                 double burst_timer = 0;
                 double expected_burst_timer = 0;
-                p->SetBurstTimer(burst_timer);
+                phage->SetBurstTimer(burst_timer);
 
                 bool expected_dead = false;
-                long unsigned int expected_repro_syms_size = size(h->GetReproSymbionts());
+                long unsigned int expected_repro_syms_size = size(bacterium->GetReproSymbionts());
 
-                p->Process(location);
+                phage->Process(location);
 
                 THEN("The phage does nothing; it is temperate and still alive"){
-                    REQUIRE(p->GetIntVal() == expected_int_val);
-                    REQUIRE(p->GetPoints() == expected_points);
-                    REQUIRE(p->GetBurstTimer() == expected_burst_timer);
-                    REQUIRE(size(h->GetReproSymbionts()) == expected_repro_syms_size);
-                    REQUIRE(p->GetDead() == expected_dead);
+                    REQUIRE(phage->GetIntVal() == expected_int_val);
+                    REQUIRE(phage->GetPoints() == expected_points);
+                    REQUIRE(phage->GetBurstTimer() == expected_burst_timer);
+                    REQUIRE(size(bacterium->GetReproSymbionts()) == expected_repro_syms_size);
+                    REQUIRE(phage->GetDead() == expected_dead);
                 }
-                delete h;
+                bacterium.Delete();
             }
         }
     }
@@ -492,72 +495,72 @@ TEST_CASE("Phage process", "[lysis]"){
 
         WHEN("It is time to burst"){
             double int_val = 0;
-            emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
+            emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
 
             //create two hosts and add both to world as neighbors
-            Bacterium * orig_h = new Bacterium(random, &w, &config, int_val);
-            Bacterium * new_h = new Bacterium(random, &w, &config, int_val);
-            orig_h->AddSymbiont(p);
-            world->AddOrgAt(orig_h, 0);
-            world->AddOrgAt(new_h, 1);
+            emp::Ptr<Bacterium> orig_bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+            emp::Ptr<Bacterium> new_bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+            orig_bacterium->AddSymbiont(phage);
+            world->AddOrgAt(orig_bacterium, 0);
+            world->AddOrgAt(new_bacterium, 1);
 
             //add phage offspring to the original host's repro syms
-            emp::Ptr<Organism> p_baby1 = p->reproduce();
-            emp::Ptr<Organism> p_baby2 = p->reproduce();
-            orig_h->AddReproSym(p_baby1);
-            orig_h->AddReproSym(p_baby2);
+            emp::Ptr<Organism> p_baby1 = phage->reproduce();
+            emp::Ptr<Organism> p_baby2 = phage->reproduce();
+            orig_bacterium->AddReproSym(p_baby1);
+            orig_bacterium->AddReproSym(p_baby2);
 
             //call the process such that the phage bursts and we can check injection
-            p->SetBurstTimer(burst_timer);
-            p->Process(location);
+            phage->SetBurstTimer(burst_timer);
+            phage->Process(location);
 
             THEN("The phage offspring are injected into new hosts and the current host dies"){
-                REQUIRE(size(new_h->GetSymbionts()) > 0);
-                REQUIRE(size(orig_h->GetReproSymbionts()) == 0);
-                REQUIRE(orig_h->GetDead() == true);
+                REQUIRE(size(new_bacterium->GetSymbionts()) > 0);
+                REQUIRE(size(orig_bacterium->GetReproSymbionts()) == 0);
+                REQUIRE(orig_bacterium->GetDead() == true);
             }
         }
 
         WHEN("It is not time to burst"){
             double int_val = 0;
-            emp::Ptr<Phage> p = new Phage(random, world, &config, int_val);
-            Bacterium * h = new Bacterium(random, &w, &config, int_val);
-            h->AddSymbiont(p);
+            emp::Ptr<Phage> phage = emp::NewPtr<Phage>(random, world, &config, int_val);
+            emp::Ptr<Bacterium> bacterium = emp::NewPtr<Bacterium>(random, &w, &config, int_val);
+            bacterium->AddSymbiont(phage);
 
-            p->SetBurstTimer(0.0);
+            phage->SetBurstTimer(0.0);
 
             WHEN("The phage doesn't have enough resources to reproduce"){
-                double repro_syms_size_pre_process = size(h->GetReproSymbionts());
+                double repro_syms_size_pre_process = size(bacterium->GetReproSymbionts());
                 double orig_points = 3.0;
                 double expected_points = 3.0;
-                p->SetPoints(orig_points);
-                p->Process(location);
+                phage->SetPoints(orig_points);
+                phage->Process(location);
 
                 THEN("The burst timer is incremented but no offspring are created"){
-                    REQUIRE(p->GetBurstTimer() <= 0 + 1*3);
-                    REQUIRE(p->GetBurstTimer() >= 0 - 1*3);
-                    REQUIRE(p->GetBurstTimer() != 0);
-                    REQUIRE(size(h->GetReproSymbionts()) == repro_syms_size_pre_process);
-                    REQUIRE(p->GetPoints() == expected_points);
+                    REQUIRE(phage->GetBurstTimer() <= 0 + 1*3);
+                    REQUIRE(phage->GetBurstTimer() >= 0 - 1*3);
+                    REQUIRE(phage->GetBurstTimer() != 0);
+                    REQUIRE(size(bacterium->GetReproSymbionts()) == repro_syms_size_pre_process);
+                    REQUIRE(phage->GetPoints() == expected_points);
                 }
             }
 
             WHEN("The phage has enough resources to reproduce"){
-                double expected_repro_syms_size_post_process = size(h->GetReproSymbionts()) + 1; //one offspring created
+                double expected_repro_syms_size_post_process = size(bacterium->GetReproSymbionts()) + 1; //one offspring created
                 double orig_points = sym_repro_points;//symbiont given enough resources to produce one offspring
                 double expected_points = 0.0;
-                p->SetPoints(orig_points);
-                p->Process(location);
+                phage->SetPoints(orig_points);
+                phage->Process(location);
 
                 THEN("The burst timer is incremented and offspring are created"){
-                    REQUIRE(p->GetBurstTimer() <= 0 + 1*3);
-                    REQUIRE(p->GetBurstTimer() >= 0 - 1*3);
-                    REQUIRE(p->GetBurstTimer() != 0);
-                    REQUIRE(size(h->GetReproSymbionts()) == expected_repro_syms_size_post_process);
-                    REQUIRE(p->GetPoints() == expected_points);
+                    REQUIRE(phage->GetBurstTimer() <= 0 + 1*3);
+                    REQUIRE(phage->GetBurstTimer() >= 0 - 1*3);
+                    REQUIRE(phage->GetBurstTimer() != 0);
+                    REQUIRE(size(bacterium->GetReproSymbionts()) == expected_repro_syms_size_post_process);
+                    REQUIRE(phage->GetPoints() == expected_points);
                 }
             }
-            delete h;
+            bacterium.Delete();
         }
 
     }
@@ -578,21 +581,21 @@ TEST_CASE("Phage ProcessResources", "[lysis]"){
             config.BENEFIT_TO_HOST(0);
 
             double int_val=0;
-            emp::Ptr<Phage> p;
-            p.New(random, world, &config, int_val);
-            emp::Ptr<Bacterium> b;
-            b.New(random, world, &config, int_val);
-            b->AddSymbiont(p);
-            p->uponInjection();
+            emp::Ptr<Phage> phage;
+            phage.New(random, world, &config, int_val);
+            emp::Ptr<Bacterium> bacterium;
+            bacterium.New(random, world, &config, int_val);
+            bacterium->AddSymbiont(phage);
+            phage->uponInjection();
 
             double sym_piece = 40;
             double expected_return = 0;
 
             THEN("Phage doesn't take or give resources to the host"){
-                REQUIRE(p->ProcessResources(sym_piece)==expected_return);
+                REQUIRE(phage->ProcessResources(sym_piece)==expected_return);
             }
 
-            p.Delete();
+            bacterium.Delete();
         }
 
         WHEN("Benefits to the host are enabled"){
@@ -605,56 +608,58 @@ TEST_CASE("Phage ProcessResources", "[lysis]"){
             double orig_host_resources = 10;
             double sym_piece = 0;
             double int_val=0;
-            emp::Ptr<Bacterium> b;
-            b.New(random, world, &config, int_val);
+            emp::Ptr<Bacterium> bacterium;
+            bacterium.New(random, world, &config, int_val);
 
             WHEN("The incorporation vals are similar"){
                 config.PHAGE_INC_VAL(0);
 
-                emp::Ptr<Phage> p;
-                p.New(random, world, &config, int_val);
+                emp::Ptr<Phage> phage;
+                phage.New(random, world, &config, int_val);
 
-                b->AddSymbiont(p);
-                b->SetResInProcess(orig_host_resources);
+                bacterium->AddSymbiont(phage);
+                bacterium->SetResInProcess(orig_host_resources);
 
                 double expected_resources = 20;
 
                 THEN("The host resources increase"){
-                    REQUIRE(p->ProcessResources(sym_piece)==expected_resources);
+                    REQUIRE(phage->ProcessResources(sym_piece)==expected_resources);
                 }
             }
 
             WHEN("The incorporation vals are neutral"){
                 config.PHAGE_INC_VAL(0.5);
 
-                emp::Ptr<Phage> p;
-                p.New(random, world, &config, int_val);
+                emp::Ptr<Phage> phage;
+                phage.New(random, world, &config, int_val);
 
-                b->AddSymbiont(p);
-                b->SetResInProcess(orig_host_resources);
+                bacterium->AddSymbiont(phage);
+                bacterium->SetResInProcess(orig_host_resources);
 
                 double expected_resources = 10;
 
                 THEN("The host resources stay the same"){
-                    REQUIRE(p->ProcessResources(sym_piece)==expected_resources);
+                    REQUIRE(phage->ProcessResources(sym_piece)==expected_resources);
                 }
             }
 
             WHEN("The incorporation vals are far apart"){
                 config.PHAGE_INC_VAL(1);
 
-                emp::Ptr<Phage> p;
-                p.New(random, world, &config, int_val);
+                emp::Ptr<Phage> phage;
+                phage.New(random, world, &config, int_val);
 
-                b->AddSymbiont(p);
-                b->SetResInProcess(orig_host_resources);
+                bacterium->AddSymbiont(phage);
+                bacterium->SetResInProcess(orig_host_resources);
 
                 double expected_resources = 0;
 
                 THEN("The host resources are diminished"){
-                    REQUIRE(p->ProcessResources(sym_piece)==expected_resources);
+                    REQUIRE(phage->ProcessResources(sym_piece)==expected_resources);
                 }
             }
+
+            bacterium.Delete();
         }
     }
 }
@@ -665,20 +670,23 @@ TEST_CASE("Phage makeNew", "[lysis]"){
     SymConfigBase config;
 
     double phage_int_val = 0.2;
-    Organism * p1 = new Phage(random, &w, &config, phage_int_val);
-    Organism * p2 = p1->makeNew();
+    emp::Ptr<Organism> phage = emp::NewPtr<Phage>(random, &w, &config, phage_int_val);
+    emp::Ptr<Organism> new_phage = phage->makeNew();
 
     THEN("The new phage has the same genome as its parent, but age and points 0"){
-        REQUIRE(p2->GetIntVal() == p1->GetIntVal());
-        REQUIRE(p2->GetIncVal() == p1->GetIncVal());
-        REQUIRE(p2->GetLysisChance() == p1->GetLysisChance());
-        REQUIRE(p2->GetInductionChance() == p1->GetInductionChance());
-        REQUIRE(p2->GetInfectionChance() == p1->GetInfectionChance());
-        REQUIRE(p2->GetAge() == 0);
-        REQUIRE(p2->GetPoints() == 0);
-        REQUIRE(p2->GetBurstTimer() == 0);
+        REQUIRE(new_phage->GetIntVal() == phage->GetIntVal());
+        REQUIRE(new_phage->GetIncVal() == phage->GetIncVal());
+        REQUIRE(new_phage->GetLysisChance() == phage->GetLysisChance());
+        REQUIRE(new_phage->GetInductionChance() == phage->GetInductionChance());
+        REQUIRE(new_phage->GetInfectionChance() == phage->GetInfectionChance());
+        REQUIRE(new_phage->GetAge() == 0);
+        REQUIRE(new_phage->GetPoints() == 0);
+        REQUIRE(new_phage->GetBurstTimer() == 0);
 
         //check that the offspring is the correct class
-        REQUIRE(typeid(*p2).name() == typeid(*p1).name());
+        REQUIRE(typeid(*new_phage).name() == typeid(*phage).name());
     }
+
+    phage.Delete();
+    new_phage.Delete();
 }

--- a/source/test/pgg_mode_test/PGGDataNodes.test.cc
+++ b/source/test/pgg_mode_test/PGGDataNodes.test.cc
@@ -32,12 +32,12 @@ TEST_CASE("GetPGGDataNode", "[pgg]"){
       expected_hist_counts[7] = 2;
       expected_hist_counts[9] = 1;
 
-      Host *host = new PGGHost(&random, &w, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<PGGHost>(&random, &w, &config, int_val);
       w.AddOrgAt(host, 0);
 
       for(size_t i = 0; i < 3; i++){
-        w.AddOrgAt(new PGGSymbiont(&random, &w, &config, int_val, free_sym_donation_vals[i]), emp::WorldPosition(0, i));
-        host->AddSymbiont(new PGGSymbiont(&random, &w, &config, int_val, hosted_sym_donation_vals[i]));
+        w.AddOrgAt(emp::NewPtr<PGGSymbiont>(&random, &w, &config, int_val, free_sym_donation_vals[i]), emp::WorldPosition(0, i));
+        host->AddSymbiont(emp::NewPtr<PGGSymbiont>(&random, &w, &config, int_val, hosted_sym_donation_vals[i]));
       }
 
       w.Update();

--- a/source/test/pgg_mode_test/PGGHost.test.cc
+++ b/source/test/pgg_mode_test/PGGHost.test.cc
@@ -9,12 +9,12 @@ TEST_CASE("PGGHost constructor", "[pgg]"){
     PGGWorld * world = &w;
 
     double int_val = -2;
-    REQUIRE_THROWS(new PGGHost(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<PGGHost>(random, world, &config, int_val) );
 
     int_val = -1;
-    PGGHost * h1 = new PGGHost(random, world, &config, int_val);
+    emp::Ptr<PGGHost> h1 = emp::NewPtr<PGGHost>(random, world, &config, int_val);
     CHECK(h1->GetIntVal() == int_val);
-    CHECK(h1->GetAge() == 0); 
+    CHECK(h1->GetAge() == 0);
     CHECK(h1->GetPoints() == 0);
 
     int_val = -1;
@@ -22,19 +22,23 @@ TEST_CASE("PGGHost constructor", "[pgg]"){
     emp::vector<emp::Ptr<Organism>> repro_syms = {};
     std::set<int> set = std::set<int>();
     double points = 10;
-    PGGHost * h2 = new PGGHost(random, world, &config, int_val, syms, repro_syms, set, points);
+    emp::Ptr<PGGHost> h2 = emp::NewPtr<PGGHost>(random, world, &config, int_val, syms, repro_syms, set, points);
     CHECK(h2->GetIntVal() == int_val);
     CHECK(h2->GetAge() == 0);
     CHECK(h2->GetPoints() == points);
 
     int_val = 1;
-    PGGHost * h3 = new PGGHost(random, world, &config, int_val);
+    emp::Ptr<PGGHost> h3 = emp::NewPtr<PGGHost>(random, world, &config, int_val);
     CHECK(h3->GetIntVal() == int_val);
     CHECK(h3->GetAge() == 0);
     CHECK(h3->GetPoints() == 0);
 
     int_val = 2;
-    REQUIRE_THROWS(new PGGHost(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<PGGHost>(random, world, &config, int_val) );
+
+    h1.Delete();
+    h2.Delete();
+    h3.Delete();
 }
 
 TEST_CASE("PGGHost get pool", "[pgg]") {
@@ -43,15 +47,17 @@ TEST_CASE("PGGHost get pool", "[pgg]") {
     PGGWorld w(*random);
     double pool = 1;
 
-    PGGHost * h1 = new PGGHost(random, &w, &config);
+    emp::Ptr<PGGHost> h1 = emp::NewPtr<PGGHost>(random, &w, &config);
     double default_pool = 0.0;
     REQUIRE(h1->GetPool() == default_pool);
 
-    PGGHost * h2 = new PGGHost(random, &w, &config);
+    emp::Ptr<PGGHost> h2 = emp::NewPtr<PGGHost>(random, &w, &config);
     h2->SetPool(pool);
     double expected_pool = 1;
     REQUIRE(h2->GetPool() == expected_pool);
 
+    h1.Delete();
+    h2.Delete();
 }
 
 TEST_CASE("PGGHost DistributeResources", "[pgg]") {
@@ -66,7 +72,7 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
         double orig_points = 0; // call this default_points instead? (i'm not setting this val)
         config.SYNERGY(5);
 
-        Host * h = new PGGHost(random, &w, &config, int_val);
+        emp::Ptr<Host> h = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
         h->DistribResources(resources);
 
         THEN("Points increase") {
@@ -75,6 +81,7 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
             REQUIRE(points == expected_points);
             REQUIRE(points > orig_points);
         }
+        h.Delete();
     }
 
 
@@ -85,7 +92,7 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
         double orig_points = 0;
         config.SYNERGY(5);
 
-        Host * h = new PGGHost(random, &w, &config, int_val);
+        emp::Ptr<Host> h = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
         h->DistribResources(resources);
 
         THEN("Resources are added to points") {
@@ -93,6 +100,7 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
             double points = h->GetPoints();
             REQUIRE(points == expected_points);
         }
+        h.Delete();
     }
 
     WHEN("There are no symbionts and interaction value is between -1 and 0") {
@@ -102,7 +110,7 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
         double orig_points = 27;
         config.SYNERGY(5);
 
-        Host * h = new PGGHost(random, &w, &config, int_val);
+        emp::Ptr<Host> h = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
         h->AddPoints(orig_points);
         h->DistribResources(resources);
 
@@ -114,6 +122,7 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
             REQUIRE(points == expected_points);
             REQUIRE(points > orig_points);
         }
+        h.Delete();
     }
 }
 
@@ -123,8 +132,8 @@ TEST_CASE("PGGHost makeNew", "[pgg]"){
     SymConfigBase config;
 
     double host_int_val = 0.2;
-    Organism * h1 = new PGGHost(random, &w, &config, host_int_val);
-    Organism * h2 = h1->makeNew();
+    emp::Ptr<Organism> h1 = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+    emp::Ptr<Organism> h2 = h1->makeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
       REQUIRE(h1->GetIntVal() == h2->GetIntVal());
       REQUIRE(h2->GetPoints() == 0);
@@ -132,4 +141,6 @@ TEST_CASE("PGGHost makeNew", "[pgg]"){
       //check that the offspring is the correct class
       REQUIRE(typeid(*h2).name() == typeid(*h1).name());
     }
+    h1.Delete();
+    h2.Delete();
 }

--- a/source/test/pgg_mode_test/PGGHost.test.cc
+++ b/source/test/pgg_mode_test/PGGHost.test.cc
@@ -12,33 +12,33 @@ TEST_CASE("PGGHost constructor", "[pgg]"){
     REQUIRE_THROWS(emp::NewPtr<PGGHost>(random, world, &config, int_val) );
 
     int_val = -1;
-    emp::Ptr<PGGHost> h1 = emp::NewPtr<PGGHost>(random, world, &config, int_val);
-    CHECK(h1->GetIntVal() == int_val);
-    CHECK(h1->GetAge() == 0);
-    CHECK(h1->GetPoints() == 0);
+    emp::Ptr<PGGHost> host1 = emp::NewPtr<PGGHost>(random, world, &config, int_val);
+    CHECK(host1->GetIntVal() == int_val);
+    CHECK(host1->GetAge() == 0);
+    CHECK(host1->GetPoints() == 0);
 
     int_val = -1;
     emp::vector<emp::Ptr<Organism>> syms = {};
     emp::vector<emp::Ptr<Organism>> repro_syms = {};
     std::set<int> set = std::set<int>();
     double points = 10;
-    emp::Ptr<PGGHost> h2 = emp::NewPtr<PGGHost>(random, world, &config, int_val, syms, repro_syms, set, points);
-    CHECK(h2->GetIntVal() == int_val);
-    CHECK(h2->GetAge() == 0);
-    CHECK(h2->GetPoints() == points);
+    emp::Ptr<PGGHost> host2 = emp::NewPtr<PGGHost>(random, world, &config, int_val, syms, repro_syms, set, points);
+    CHECK(host2->GetIntVal() == int_val);
+    CHECK(host2->GetAge() == 0);
+    CHECK(host2->GetPoints() == points);
 
     int_val = 1;
-    emp::Ptr<PGGHost> h3 = emp::NewPtr<PGGHost>(random, world, &config, int_val);
-    CHECK(h3->GetIntVal() == int_val);
-    CHECK(h3->GetAge() == 0);
-    CHECK(h3->GetPoints() == 0);
+    emp::Ptr<PGGHost> host3 = emp::NewPtr<PGGHost>(random, world, &config, int_val);
+    CHECK(host3->GetIntVal() == int_val);
+    CHECK(host3->GetAge() == 0);
+    CHECK(host3->GetPoints() == 0);
 
     int_val = 2;
     REQUIRE_THROWS(emp::NewPtr<PGGHost>(random, world, &config, int_val) );
 
-    h1.Delete();
-    h2.Delete();
-    h3.Delete();
+    host1.Delete();
+    host2.Delete();
+    host3.Delete();
 }
 
 TEST_CASE("PGGHost get pool", "[pgg]") {
@@ -47,17 +47,17 @@ TEST_CASE("PGGHost get pool", "[pgg]") {
     PGGWorld w(*random);
     double pool = 1;
 
-    emp::Ptr<PGGHost> h1 = emp::NewPtr<PGGHost>(random, &w, &config);
+    emp::Ptr<PGGHost> host1 = emp::NewPtr<PGGHost>(random, &w, &config);
     double default_pool = 0.0;
-    REQUIRE(h1->GetPool() == default_pool);
+    REQUIRE(host1->GetPool() == default_pool);
 
-    emp::Ptr<PGGHost> h2 = emp::NewPtr<PGGHost>(random, &w, &config);
-    h2->SetPool(pool);
+    emp::Ptr<PGGHost> host2 = emp::NewPtr<PGGHost>(random, &w, &config);
+    host2->SetPool(pool);
     double expected_pool = 1;
-    REQUIRE(h2->GetPool() == expected_pool);
+    REQUIRE(host2->GetPool() == expected_pool);
 
-    h1.Delete();
-    h2.Delete();
+    host1.Delete();
+    host2.Delete();
 }
 
 TEST_CASE("PGGHost DistributeResources", "[pgg]") {
@@ -72,16 +72,16 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
         double orig_points = 0; // call this default_points instead? (i'm not setting this val)
         config.SYNERGY(5);
 
-        emp::Ptr<Host> h = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
-        h->DistribResources(resources);
+        emp::Ptr<Host> host = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
+        host->DistribResources(resources);
 
         THEN("Points increase") {
             double expected_points = resources - (resources * int_val); // 48
-            double points = h->GetPoints();
+            double points = host->GetPoints();
             REQUIRE(points == expected_points);
             REQUIRE(points > orig_points);
         }
-        h.Delete();
+        host.Delete();
     }
 
 
@@ -92,15 +92,15 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
         double orig_points = 0;
         config.SYNERGY(5);
 
-        emp::Ptr<Host> h = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
-        h->DistribResources(resources);
+        emp::Ptr<Host> host = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
+        host->DistribResources(resources);
 
         THEN("Resources are added to points") {
             double expected_points = orig_points + resources; // 0
-            double points = h->GetPoints();
+            double points = host->GetPoints();
             REQUIRE(points == expected_points);
         }
-        h.Delete();
+        host.Delete();
     }
 
     WHEN("There are no symbionts and interaction value is between -1 and 0") {
@@ -110,19 +110,19 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
         double orig_points = 27;
         config.SYNERGY(5);
 
-        emp::Ptr<Host> h = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
-        h->AddPoints(orig_points);
-        h->DistribResources(resources);
+        emp::Ptr<Host> host = emp::NewPtr<PGGHost>(random, &w, &config, int_val);
+        host->AddPoints(orig_points);
+        host->DistribResources(resources);
 
         THEN("Points increase") {
             double host_defense =  -1.0 * int_val * resources; // the resources spent on defense
             double add_points  = resources - host_defense;
             double expected_points = orig_points + add_points;
-            double points = h->GetPoints();
+            double points = host->GetPoints();
             REQUIRE(points == expected_points);
             REQUIRE(points > orig_points);
         }
-        h.Delete();
+        host.Delete();
     }
 }
 
@@ -132,15 +132,15 @@ TEST_CASE("PGGHost MakeNew", "[pgg]"){
     SymConfigBase config;
 
     double host_int_val = 0.2;
-    emp::Ptr<Organism> h1 = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-    emp::Ptr<Organism> h2 = h1->MakeNew();
+    emp::Ptr<Organism> host1 = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+    emp::Ptr<Organism> host2 = host1->MakeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
-      REQUIRE(h1->GetIntVal() == h2->GetIntVal());
-      REQUIRE(h2->GetPoints() == 0);
-      REQUIRE(h2->GetAge() == 0);
+      REQUIRE(host1->GetIntVal() == host2->GetIntVal());
+      REQUIRE(host2->GetPoints() == 0);
+      REQUIRE(host2->GetAge() == 0);
       //check that the offspring is the correct class
-      REQUIRE(typeid(*h2).name() == typeid(*h1).name());
+      REQUIRE(typeid(*host2).name() == typeid(*host1).name());
     }
-    h1.Delete();
-    h2.Delete();
+    host1.Delete();
+    host2.Delete();
 }

--- a/source/test/pgg_mode_test/PGGHost.test.cc
+++ b/source/test/pgg_mode_test/PGGHost.test.cc
@@ -126,14 +126,14 @@ TEST_CASE("PGGHost DistributeResources", "[pgg]") {
     }
 }
 
-TEST_CASE("PGGHost makeNew", "[pgg]"){
+TEST_CASE("PGGHost MakeNew", "[pgg]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     PGGWorld w(*random);
     SymConfigBase config;
 
     double host_int_val = 0.2;
     emp::Ptr<Organism> h1 = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-    emp::Ptr<Organism> h2 = h1->makeNew();
+    emp::Ptr<Organism> h2 = h1->MakeNew();
     THEN("The new host has properties of the original host and has 0 points and 0 age"){
       REQUIRE(h1->GetIntVal() == h2->GetIntVal());
       REQUIRE(h2->GetPoints() == 0);

--- a/source/test/pgg_mode_test/PGGHostPGGSymbiontUnitTest.test.cc
+++ b/source/test/pgg_mode_test/PGGHostPGGSymbiontUnitTest.test.cc
@@ -8,15 +8,15 @@ TEST_CASE("PGGSymbiont SetHost, GetHost", "[pgg]") {
     PGGWorld w(*random);
     double int_val = 1;
 
-    emp::Ptr<Organism> h = emp::NewPtr<PGGHost>(random, &w, &config);
-    emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, &w, &config, int_val);
+    emp::Ptr<Organism> host = emp::NewPtr<PGGHost>(random, &w, &config);
+    emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, &w, &config, int_val);
 
-    s->SetHost(h);
+    symbiont->SetHost(host);
 
-    REQUIRE(s->GetHost() == h);
+    REQUIRE(symbiont->GetHost() == host);
 
-    h.Delete();
-    s.Delete();
+    host.Delete();
+    symbiont.Delete();
 }
 
 TEST_CASE("PGGHost DistribResources", "[pgg]") {
@@ -31,17 +31,17 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_int_val = 0.5;
         double sym_int_val = 1;
 
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-        emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-        emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-        emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
+        emp::Ptr<PGGSymbiont> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> symbiont3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::vector<emp::Ptr<Organism>> syms = {symbiont1, symbiont2, symbiont3};
+        host->SetSymbionts(syms);
 
         double resources = 120;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
 
         int num_syms = 3;
@@ -52,7 +52,7 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double sym_portion = host_donation - (host_donation * sym_int_val);
         host_portion += sym_return;
 
-        double host_points = num_syms * host_portion; // * by num_syms bc points are added during each iteration through host's syms
+        double host_points = num_syms * host_portion; // * by num_syms bc points are added during each iteration through host'symbiont syms
         double sym_points = sym_portion;
 
 
@@ -61,9 +61,9 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             for( emp::Ptr<Organism> symbiont : syms) {
                 REQUIRE(symbiont->GetPoints() == sym_points);
             }
-            REQUIRE(h->GetPoints() == host_points);
+            REQUIRE(host->GetPoints() == host_points);
         }
-        h.Delete();
+        host.Delete();
     }
 
 
@@ -74,32 +74,32 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             double host_orig_points = 0;
             double sym_orig_points = 0;
 
-            emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+            emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-            emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-            emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-            emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-            emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-            h->SetSymbionts(syms);
+            emp::Ptr<PGGSymbiont> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> symbiont3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::vector<emp::Ptr<Organism>> syms = {symbiont1, symbiont2, symbiont3};
+            host->SetSymbionts(syms);
 
             double resources = 120;
-            h->DistribResources(resources);
+            host->DistribResources(resources);
 
             int num_syms = 3;
             double sym_piece = resources / num_syms; // how much resource each sym gets
             double host_defense = -1 * (host_int_val * sym_piece);
             double remaining_resources = sym_piece - host_defense;
-            double host_points = remaining_resources * num_syms; // * by num_syms bc points are added during each iteration through host's syms
+            double host_points = remaining_resources * num_syms; // * by num_syms bc points are added during each iteration through host'symbiont syms
 
             THEN("Symbiont points do not change (gets nothing from host), Host points increase") {
                 for( emp::Ptr<Organism> symbiont : syms) {
                     REQUIRE(symbiont->GetPoints() == sym_orig_points);
                 }
-                REQUIRE(h->GetPoints() == host_points);
-                REQUIRE(h->GetPoints() > host_orig_points);
+                REQUIRE(host->GetPoints() == host_points);
+                REQUIRE(host->GetPoints() > host_orig_points);
             }
-            h.Delete();
+            host.Delete();
         }
 
         WHEN("Host interaction value > Symbionts' interaction value") {
@@ -108,17 +108,17 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             double host_orig_points = 0;
             double sym_orig_points = 0;
 
-            emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+            emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-            emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-            emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-            emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-            emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-            h->SetSymbionts(syms);
+            emp::Ptr<PGGSymbiont> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> symbiont3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::vector<emp::Ptr<Organism>> syms = {symbiont1, symbiont2, symbiont3};
+            host->SetSymbionts(syms);
 
             double resources = 120;
-            h->DistribResources(resources);
+            host->DistribResources(resources);
 
             int num_syms = 3;
             double sym_piece = resources / num_syms; // how much resource each sym gets
@@ -126,17 +126,17 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             double remaining_resources = sym_piece - host_defense;
             double sym_steals = (host_int_val - sym_int_val) * remaining_resources;
             double sym_points = sym_steals;
-            double host_points = (remaining_resources - sym_steals) * num_syms; // * by num_syms bc points are added during each iteration through host's syms
+            double host_points = (remaining_resources - sym_steals) * num_syms; // * by num_syms bc points are added during each iteration through host'symbiont syms
 
             THEN("Symbionts points and Host points increase") {
                 for( emp::Ptr<Organism> symbiont : syms) {
                     REQUIRE(symbiont->GetPoints() == sym_points);
                     REQUIRE(symbiont->GetPoints() > sym_orig_points);
                 }
-                REQUIRE(h->GetPoints() == host_points);
-                REQUIRE(h->GetPoints() > host_orig_points);
+                REQUIRE(host->GetPoints() == host_points);
+                REQUIRE(host->GetPoints() > host_orig_points);
             }
-            h.Delete();
+            host.Delete();
         }
     }
     WHEN("Host interaction value > 0 and Symbiont interaction value < 0, single symbiont") {
@@ -145,24 +145,24 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_orig_points = 0;
         double sym_orig_points = 0;
 
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
-        h->AddSymbiont(s);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        host->AddSymbiont(symbiont);
 
         int resources = 100;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
         // int host_donation = 10; //host_int_val * resources
         int host_portion = 90;  //remaining amount
         int sym_steals = 9; //host_portion * sym_int_val * -1; new code value should be 18
         int sym_portion = 19; //sym_steals + host_donation; new code value should be 28
-        host_portion = host_portion - sym_steals; //remove stolen resources from host's portion
+        host_portion = host_portion - sym_steals; //remove stolen resources from host'symbiont portion
 
         THEN("Symbionts points and Host points increase the correct amounts") {
-            REQUIRE(s->GetPoints() == sym_orig_points+sym_portion);
-            REQUIRE(h->GetPoints() == host_orig_points+host_portion);
+            REQUIRE(symbiont->GetPoints() == sym_orig_points+sym_portion);
+            REQUIRE(host->GetPoints() == host_orig_points+host_portion);
         }
-        h.Delete();
+        host.Delete();
     }
     WHEN("Host interaction value > 0 and Symbiont interaction value < 0, multiple symbionts") {
         double host_int_val = 0.1;
@@ -170,17 +170,17 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_orig_points = 0;
         double sym_orig_points = 0;
 
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-        emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
-        emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
-        emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
+        emp::Ptr<PGGSymbiont> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<PGGSymbiont> symbiont3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::vector<emp::Ptr<Organism>> syms = {symbiont1, symbiont2, symbiont3};
+        host->SetSymbionts(syms);
 
         double resources = 120;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
 
         int num_syms = 3;
@@ -190,7 +190,7 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_portion = 36;  //remaining amount
         double sym_steals = 3.6; //host_portion * sym_int_val * -1
         double sym_portion = 7.6; //sym_steals + host_donation
-        host_portion = host_portion - sym_steals; //remove stolen resources from host's portion
+        host_portion = host_portion - sym_steals; //remove stolen resources from host'symbiont portion
 
         double host_final_portion = host_portion * num_syms;
 
@@ -203,10 +203,10 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
                REQUIRE(symbiont->GetPoints() > sym_orig_points);
             }
 
-            REQUIRE(h->GetPoints() == host_final_portion);
-            REQUIRE(h->GetPoints() > host_orig_points);
+            REQUIRE(host->GetPoints() == host_final_portion);
+            REQUIRE(host->GetPoints() > host_orig_points);
         }
-        h.Delete();
+        host.Delete();
     }
 
 
@@ -216,17 +216,17 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_orig_points = 0;
         double symbiont_orig_points = 0;
 
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-        emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-        emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-        emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
+        emp::Ptr<PGGSymbiont> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> symbiont3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::vector<emp::Ptr<Organism>> syms = {symbiont1, symbiont2, symbiont3};
+        host->SetSymbionts(syms);
 
         double resources = 120;
-        h->DistribResources(resources);
+        host->DistribResources(resources);
 
         int num_syms = 3;
         double sym_piece = resources / num_syms;
@@ -235,18 +235,18 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double sym_portion = 0;
 
         double sym_points = sym_portion;
-        double host_points = host_portion * num_syms; // * by num_syms bc points are added during each iteration through host's syms
+        double host_points = host_portion * num_syms; // * by num_syms bc points are added during each iteration through host'symbiont syms
 
         THEN("Symbiont points do not change (gets nothing from host), Host points increase") {
             for( emp::Ptr<Organism> symbiont : syms) {
                 REQUIRE(symbiont->GetPoints() == sym_points);
                 REQUIRE(symbiont->GetPoints() == symbiont_orig_points);
             }
-            REQUIRE(h->GetPoints() == host_points);
-            REQUIRE(h->GetPoints() > host_orig_points);
+            REQUIRE(host->GetPoints() == host_points);
+            REQUIRE(host->GetPoints() > host_orig_points);
 
         }
-        h.Delete();
+        host.Delete();
     }
 }
 
@@ -262,38 +262,38 @@ TEST_CASE("PGGVertical Transmission of Symbiont", "[pgg]") {
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
 
-        emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, world, &config, h->GetIntVal());
+        emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, world, &config, host->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size() + 1;
-        s->VerticalTransmission(host_baby);
+        symbiont->VerticalTransmission(host_baby);
 
         THEN("Symbiont offspring are injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
         host_baby.Delete();
-        h.Delete();
-        s.Delete();
+        host.Delete();
+        symbiont.Delete();
     }
     WHEN("When vertical transmission is disabled"){
         world->SetVertTrans(0);
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
 
-        emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, world, &config, h->GetIntVal());
+        emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, world, &config, host->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size();
-        s->VerticalTransmission(host_baby);
+        symbiont->VerticalTransmission(host_baby);
 
         THEN("Symbiont offspring are not injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
         host_baby.Delete();
-        h.Delete();
-        s.Delete();
+        host.Delete();
+        symbiont.Delete();
     }
 
 }
@@ -311,15 +311,15 @@ TEST_CASE("PGGSymbiont  PGGHost Pool Interaction", "[pgg]"){
     double donation = 0.1;
     double donation2 = 0.2;
 
-    emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+    emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-    emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation);
-    emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation2);
-    emp::vector<emp::Ptr<Organism>> syms = {s1, s2};
-    h->SetSymbionts(syms);
+    emp::Ptr<PGGSymbiont> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation);
+    emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation2);
+    emp::vector<emp::Ptr<Organism>> syms = {symbiont1, symbiont2};
+    host->SetSymbionts(syms);
     double resources = 120;
-    h->DistribResources(resources);
+    host->DistribResources(resources);
 
 
     double host_portion = 0;  //remaining amount
@@ -328,11 +328,11 @@ TEST_CASE("PGGSymbiont  PGGHost Pool Interaction", "[pgg]"){
     double s2_final_source = 48+9*1.1;
 
 
-    REQUIRE(s1->GetPoints() == s1_final_source);
-    REQUIRE(s2->GetPoints() == s2_final_source);
-    REQUIRE(h->GetPoints() == host_portion);
-    REQUIRE(h->GetPool() == host_pool);
-    h.Delete();
+    REQUIRE(symbiont1->GetPoints() == s1_final_source);
+    REQUIRE(symbiont2->GetPoints() == s2_final_source);
+    REQUIRE(host->GetPoints() == host_portion);
+    REQUIRE(host->GetPool() == host_pool);
+    host.Delete();
 }
 
 TEST_CASE("PGGSym Dead and Removal", "[pgg]") {
@@ -346,14 +346,14 @@ TEST_CASE("PGGSym Dead and Removal", "[pgg]") {
     double host_int_val = .5;
     double sym_int_val = -.5;
 
-    emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
+    emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
     emp::Ptr<PGGSymbiont> p = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
 
-    h->AddSymbiont(p);
+    host->AddSymbiont(p);
     p->SetDead();
 
     long unsigned int expected_sym_size = 0;
-    h->Process(0);
-    REQUIRE(h->GetSymbionts().size() == expected_sym_size);
-    h.Delete();
+    host->Process(0);
+    REQUIRE(host->GetSymbionts().size() == expected_sym_size);
+    host.Delete();
 }

--- a/source/test/pgg_mode_test/PGGHostPGGSymbiontUnitTest.test.cc
+++ b/source/test/pgg_mode_test/PGGHostPGGSymbiontUnitTest.test.cc
@@ -8,15 +8,16 @@ TEST_CASE("PGGSymbiont SetHost, GetHost", "[pgg]") {
     PGGWorld w(*random);
     double int_val = 1;
 
-    emp::Ptr<Organism> h = new PGGHost(random, &w, &config);
-    PGGSymbiont * s = new PGGSymbiont(random, &w, &config, int_val);
+    emp::Ptr<Organism> h = emp::NewPtr<PGGHost>(random, &w, &config);
+    emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, &w, &config, int_val);
 
     s->SetHost(h);
 
     REQUIRE(s->GetHost() == h);
 
+    h.Delete();
+    s.Delete();
 }
-
 
 TEST_CASE("PGGHost DistribResources", "[pgg]") {
     emp::Ptr<emp::Random> random = new emp::Random(-1);
@@ -30,12 +31,12 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_int_val = 0.5;
         double sym_int_val = 1;
 
-        PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-        PGGSymbiont * s1 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        PGGSymbiont * s2 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        PGGSymbiont * s3 = new PGGSymbiont(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
         emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
         h->SetSymbionts(syms);
 
@@ -62,25 +63,26 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             }
             REQUIRE(h->GetPoints() == host_points);
         }
+        h.Delete();
     }
 
 
     WHEN("Host interaction value <= 0 and Symbiont interaction value < 0") {
-        double host_int_val = -0.5;
-        double sym_int_val = -0.1;
-        double host_orig_points = 0;
-        double sym_orig_points = 0;
-
-        PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
-
-
-        PGGSymbiont * s1 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        PGGSymbiont * s2 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        PGGSymbiont * s3 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
-        h->SetSymbionts(syms);
-
         WHEN("Host interaction value < Symbionts' interaction value") {
+            double host_int_val = -0.5;
+            double sym_int_val = -0.1;
+            double host_orig_points = 0;
+            double sym_orig_points = 0;
+
+            emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+
+
+            emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
+            h->SetSymbionts(syms);
+
             double resources = 120;
             h->DistribResources(resources);
 
@@ -97,8 +99,8 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
                 REQUIRE(h->GetPoints() == host_points);
                 REQUIRE(h->GetPoints() > host_orig_points);
             }
+            h.Delete();
         }
-
 
         WHEN("Host interaction value > Symbionts' interaction value") {
             double host_int_val = -0.2;
@@ -106,12 +108,12 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             double host_orig_points = 0;
             double sym_orig_points = 0;
 
-            PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
+            emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-            PGGSymbiont * s1 = new PGGSymbiont(random, &w, &config, sym_int_val);
-            PGGSymbiont * s2 = new PGGSymbiont(random, &w, &config, sym_int_val);
-            PGGSymbiont * s3 = new PGGSymbiont(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+            emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
             emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
             h->SetSymbionts(syms);
 
@@ -134,6 +136,7 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
                 REQUIRE(h->GetPoints() == host_points);
                 REQUIRE(h->GetPoints() > host_orig_points);
             }
+            h.Delete();
         }
     }
     WHEN("Host interaction value > 0 and Symbiont interaction value < 0, single symbiont") {
@@ -142,8 +145,8 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_orig_points = 0;
         double sym_orig_points = 0;
 
-        Host * h = new Host(random, &w, &config, host_int_val);
-        Symbiont * s = new Symbiont(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
         h->AddSymbiont(s);
 
         int resources = 100;
@@ -159,7 +162,7 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             REQUIRE(s->GetPoints() == sym_orig_points+sym_portion);
             REQUIRE(h->GetPoints() == host_orig_points+host_portion);
         }
-
+        h.Delete();
     }
     WHEN("Host interaction value > 0 and Symbiont interaction value < 0, multiple symbionts") {
         double host_int_val = 0.1;
@@ -167,12 +170,12 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_orig_points = 0;
         double sym_orig_points = 0;
 
-        PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-        PGGSymbiont * s1 = new PGGSymbiont(random, &w, &config, sym_int_val, sym_orig_points);
-        PGGSymbiont * s2 = new PGGSymbiont(random, &w, &config, sym_int_val, sym_orig_points);
-        PGGSymbiont * s3 = new PGGSymbiont(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
+        emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val, sym_orig_points);
         emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
         h->SetSymbionts(syms);
 
@@ -203,7 +206,7 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             REQUIRE(h->GetPoints() == host_final_portion);
             REQUIRE(h->GetPoints() > host_orig_points);
         }
-
+        h.Delete();
     }
 
 
@@ -213,12 +216,12 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
         double host_orig_points = 0;
         double symbiont_orig_points = 0;
 
-        PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-        PGGSymbiont * s1 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        PGGSymbiont * s2 = new PGGSymbiont(random, &w, &config, sym_int_val);
-        PGGSymbiont * s3 = new PGGSymbiont(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
+        emp::Ptr<PGGSymbiont> s3 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val);
         emp::vector<emp::Ptr<Organism>> syms = {s1, s2, s3};
         h->SetSymbionts(syms);
 
@@ -243,6 +246,7 @@ TEST_CASE("PGGHost DistribResources", "[pgg]") {
             REQUIRE(h->GetPoints() > host_orig_points);
 
         }
+        h.Delete();
     }
 }
 
@@ -258,8 +262,8 @@ TEST_CASE("PGGVertical Transmission of Symbiont", "[pgg]") {
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<PGGHost> h = new PGGHost(random, world, &config, host_int_val);
-        emp::Ptr<PGGSymbiont> s = new PGGSymbiont(random, world, &config, sym_int_val);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
 
         emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, world, &config, h->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size() + 1;
@@ -268,14 +272,17 @@ TEST_CASE("PGGVertical Transmission of Symbiont", "[pgg]") {
         THEN("Symbiont offspring are injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
+        host_baby.Delete();
+        h.Delete();
+        s.Delete();
     }
     WHEN("When vertical transmission is disabled"){
         world->SetVertTrans(0);
         double host_int_val = .5;
         double sym_int_val = -.5;
 
-        emp::Ptr<PGGHost> h = new PGGHost(random, world, &config, host_int_val);
-        emp::Ptr<PGGSymbiont> s = new PGGSymbiont(random, world, &config, sym_int_val);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
 
         emp::Ptr<PGGHost> host_baby = emp::NewPtr<PGGHost>(random, world, &config, h->GetIntVal());
         long unsigned int expected_sym_size = host_baby->GetSymbionts().size();
@@ -284,9 +291,10 @@ TEST_CASE("PGGVertical Transmission of Symbiont", "[pgg]") {
         THEN("Symbiont offspring are not injected into host offspring") {
             REQUIRE(host_baby->GetSymbionts().size() == expected_sym_size);
         }
+        host_baby.Delete();
+        h.Delete();
+        s.Delete();
     }
-
-
 
 }
 
@@ -303,11 +311,11 @@ TEST_CASE("PGGSymbiont  PGGHost Pool Interaction", "[pgg]"){
     double donation = 0.1;
     double donation2 = 0.2;
 
-    PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
+    emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
 
 
-    PGGSymbiont * s1 = new PGGSymbiont(random, &w, &config, sym_int_val,donation);
-    PGGSymbiont * s2 = new PGGSymbiont(random, &w, &config, sym_int_val,donation2);
+    emp::Ptr<PGGSymbiont> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation);
+    emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation2);
     emp::vector<emp::Ptr<Organism>> syms = {s1, s2};
     h->SetSymbionts(syms);
     double resources = 120;
@@ -324,10 +332,10 @@ TEST_CASE("PGGSymbiont  PGGHost Pool Interaction", "[pgg]"){
     REQUIRE(s2->GetPoints() == s2_final_source);
     REQUIRE(h->GetPoints() == host_portion);
     REQUIRE(h->GetPool() == host_pool);
-
+    h.Delete();
 }
 
-TEST_CASE("PGGSYM Dead and Removal", "[pgg]") {
+TEST_CASE("PGGSym Dead and Removal", "[pgg]") {
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     PGGWorld w(*random);
     PGGWorld * world = &w;
@@ -338,8 +346,8 @@ TEST_CASE("PGGSYM Dead and Removal", "[pgg]") {
     double host_int_val = .5;
     double sym_int_val = -.5;
 
-    emp::Ptr<PGGHost> h = new PGGHost(random, world, &config, host_int_val);
-    emp::Ptr<PGGSymbiont> p = new PGGSymbiont(random, world, &config, sym_int_val);
+    emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, world, &config, host_int_val);
+    emp::Ptr<PGGSymbiont> p = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
 
     h->AddSymbiont(p);
     p->SetDead();
@@ -347,4 +355,5 @@ TEST_CASE("PGGSYM Dead and Removal", "[pgg]") {
     long unsigned int expected_sym_size = 0;
     h->Process(0);
     REQUIRE(h->GetSymbionts().size() == expected_sym_size);
+    h.Delete();
 }

--- a/source/test/pgg_mode_test/PGGSymbiont.test.cc
+++ b/source/test/pgg_mode_test/PGGSymbiont.test.cc
@@ -43,7 +43,7 @@ TEST_CASE("PGGmutate", "[pgg]") {
         config.MUTATION_SIZE(0.002);
         emp::Ptr<Organism> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
 
-        s->mutate();
+        s->Mutate();
 
         THEN("Mutation occurs and donation value changes, but stays within bounds") {
             REQUIRE(s->GetDonation() != donation);
@@ -61,7 +61,7 @@ TEST_CASE("PGGmutate", "[pgg]") {
         config.MUTATION_SIZE(0);
         emp::Ptr<Organism> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, donation);
 
-        s->mutate();
+        s->Mutate();
 
 
         THEN("Mutation does not occur and donation value does not change") {
@@ -301,14 +301,14 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
     }
 }
 
-TEST_CASE("PGGSymbiont makeNew", "[pgg]"){
+TEST_CASE("PGGSymbiont MakeNew", "[pgg]"){
     emp::Ptr<emp::Random> random = new emp::Random(-1);
     PGGWorld w(*random);
     SymConfigBase config;
 
     double host_int_val = 0.2;
     emp::Ptr<Organism> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, host_int_val);
-    emp::Ptr<Organism> s2 = s1->makeNew();
+    emp::Ptr<Organism> s2 = s1->MakeNew();
     THEN("The new symbiont has properties of the original symbiont and has 0 points and 0 age"){
       REQUIRE(s1->GetIntVal() == s2->GetIntVal());
       REQUIRE(s1->GetInfectionChance() == s2->GetInfectionChance());

--- a/source/test/pgg_mode_test/PGGSymbiont.test.cc
+++ b/source/test/pgg_mode_test/PGGSymbiont.test.cc
@@ -12,22 +12,22 @@ TEST_CASE("PGGSymbiont Constructor", "[pgg]") {
     double donation = 1;
 
     double int_val = 0.5;
-    emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
-    CHECK(s->GetDonation() == donation);
-    CHECK(s->GetAge() == 0);
-    CHECK(s->GetPoints() == 0);
+    emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
+    CHECK(symbiont->GetDonation() == donation);
+    CHECK(symbiont->GetAge() == 0);
+    CHECK(symbiont->GetPoints() == 0);
 
     donation = 2;
-    emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
-    CHECK(s2->GetDonation() == 2);
-    CHECK(s2->GetAge() == 0);
-    CHECK(s2->GetPoints() == 0);
+    emp::Ptr<PGGSymbiont> symbiont2 = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
+    CHECK(symbiont2->GetDonation() == 2);
+    CHECK(symbiont2->GetAge() == 0);
+    CHECK(symbiont2->GetPoints() == 0);
 
     int_val = 2;
     REQUIRE_THROWS(emp::NewPtr<PGGSymbiont>(random, world, &config, int_val) );
 
-    s.Delete();
-    s2.Delete();
+    symbiont.Delete();
+    symbiont2.Delete();
 }
 
 TEST_CASE("PGGmutate", "[pgg]") {
@@ -41,16 +41,16 @@ TEST_CASE("PGGmutate", "[pgg]") {
         double int_val = 0;
         double donation = 0.01;
         config.MUTATION_SIZE(0.002);
-        emp::Ptr<Organism> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
+        emp::Ptr<Organism> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
 
-        s->Mutate();
+        symbiont->Mutate();
 
         THEN("Mutation occurs and donation value changes, but stays within bounds") {
-            REQUIRE(s->GetDonation() != donation);
-            REQUIRE(s->GetDonation() <= 1);
-            REQUIRE(s->GetDonation() >= 0);
+            REQUIRE(symbiont->GetDonation() != donation);
+            REQUIRE(symbiont->GetDonation() <= 1);
+            REQUIRE(symbiont->GetDonation() >= 0);
         }
-        s.Delete();
+        symbiont.Delete();
     }
     WHEN("Mutation rate is zero") {
         double int_val = 1;
@@ -59,15 +59,15 @@ TEST_CASE("PGGmutate", "[pgg]") {
         config.HORIZ_TRANS(true);
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
-        emp::Ptr<Organism> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, donation);
+        emp::Ptr<Organism> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, donation);
 
-        s->Mutate();
+        symbiont->Mutate();
 
 
         THEN("Mutation does not occur and donation value does not change") {
-            REQUIRE(s->GetDonation() == donation);
+            REQUIRE(symbiont->GetDonation() == donation);
         }
-        s.Delete();
+        symbiont.Delete();
     }
 }
 
@@ -81,19 +81,19 @@ TEST_CASE("PGGSymbiont ProcessPool", "[pgg]"){
     double sym_int_val = 0;
     double donation = 0.1;
 
-    emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation);
-    emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-    h->AddSymbiont(s);
+    emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation);
+    emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+    host->AddSymbiont(symbiont);
 
     //double piece = 40;
     // double host_donation = 20; //sym_piece * host_int_val;
     //double sym_portion = 0; //host_donation - (host_donation * sym_int_val);
-    h->DistribResources(40);
+    host->DistribResources(40);
 
-    CHECK(s->GetPoints() == 40.4);
-    CHECK(h->GetPoints() == 0);
+    CHECK(symbiont->GetPoints() == 40.4);
+    CHECK(host->GetPoints() == 0);
 
-    h.Delete();
+    host.Delete();
 }
 
 TEST_CASE("PGGProcess", "[pgg]") {
@@ -111,20 +111,20 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(140.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int add_points = 200;
-        s->AddPoints(add_points);
+        symbiont->AddPoints(add_points);
 
         int location = 10;
-        s->Process(location);
+        symbiont->Process(location);
 
 
         THEN("Points changes and is set to 0") {
             int points_post_reproduction = 0;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(symbiont->GetPoints() == points_post_reproduction);
         }
-        s.Delete();
+        symbiont.Delete();
     }
 
 
@@ -135,20 +135,20 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(200.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0.0);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int add_points = 50;
-        s->AddPoints(add_points);
+        symbiont->AddPoints(add_points);
 
         int location = 10;
-        s->Process(location);
+        symbiont->Process(location);
 
 
         THEN("Points does not change") {
             int points_post_reproduction = 50;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(symbiont->GetPoints() == points_post_reproduction);
         }
-        s.Delete();
+        symbiont.Delete();
     }
 
 
@@ -159,17 +159,17 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(80.0);
         config.HORIZ_TRANS(false);
         config.MUTATION_SIZE(0.0);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int location = 10;
-        s->Process(location);
+        symbiont->Process(location);
 
 
         THEN("Points does not change") {
             int points_post_reproduction = 100;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(symbiont->GetPoints() == points_post_reproduction);
         }
-        s.Delete();
+        symbiont.Delete();
     }
 
     WHEN("Horizontal transmission is false and points and points is less then sym_h_res") {
@@ -179,17 +179,17 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(80.0);
         config.HORIZ_TRANS(false);
         config.MUTATION_SIZE(0.0);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int location = 10;
-        s->Process(location);
+        symbiont->Process(location);
 
 
         THEN("Points does not change") {
             int points_post_reproduction = 40;
-            REQUIRE(s->GetPoints() == points_post_reproduction);
+            REQUIRE(symbiont->GetPoints() == points_post_reproduction);
         }
-        s.Delete();
+        symbiont.Delete();
     }
 
 }
@@ -208,9 +208,9 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
 
         WHEN("host_int_val > 0"){
             double host_int_val = 0.2;
-            emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-            emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
-            h->AddSymbiont(s);
+            emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+            emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
+            host->AddSymbiont(symbiont);
 
             // double resources = 100;
             // double hostDonation = 20;
@@ -218,23 +218,23 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
             double expected_sym_points = 68; // hostDonation + stolen
             double expected_return = 0; // hostportion * synergy
 
-            h->SetResInProcess(80);
+            host->SetResInProcess(80);
 
             THEN("sym receives a donation and stolen resources, host receives betrayal"){
-                REQUIRE(s->ProcessResources(20) == expected_return);
-                REQUIRE(s->GetPoints() == expected_sym_points);
+                REQUIRE(symbiont->ProcessResources(20) == expected_return);
+                REQUIRE(symbiont->GetPoints() == expected_sym_points);
 
             }
-            h.Delete();
+            host.Delete();
         }
 
         WHEN("host_int_val < 0 and resources are placed into defense"){
 
             WHEN("host successfully defends from symsteal"){
                 double host_int_val = -0.8;
-                emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-                emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
-                h->AddSymbiont(s);
+                emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+                emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
+                host->AddSymbiont(symbiont);
 
                 // double resources = 100;
                 // double hostDonation = 0;
@@ -243,19 +243,19 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
                 double expected_sym_points = 0; // hostDonation + stolen
                 double expected_return = 0; // hostportion * synergy
 
-                h->SetResInProcess(20);
+                host->SetResInProcess(20);
                 THEN("symbiont is unsuccessful at stealing"){
-                    REQUIRE(s->ProcessResources(0) == expected_return);
-                    REQUIRE(s->GetPoints() == expected_sym_points);
+                    REQUIRE(symbiont->ProcessResources(0) == expected_return);
+                    REQUIRE(symbiont->GetPoints() == expected_sym_points);
                 }
-                h.Delete();
+                host.Delete();
             }
 
             WHEN("host fails at defense"){
                 double host_int_val = -0.5;
-                emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-                emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
-                h->AddSymbiont(s);
+                emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+                emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
+                host->AddSymbiont(symbiont);
 
                 // double resources = 100;
                 // double hostDonation = 0;
@@ -264,13 +264,13 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
                 double expected_sym_points = 5; // hostDonation + stolen
                 double expected_return = 0; // hostportion * synergy
 
-                h->SetResInProcess(50);
+                host->SetResInProcess(50);
 
                 THEN("Sym steals successfully"){
-                    REQUIRE(s->ProcessResources(0) == expected_return);
-                    REQUIRE(s->GetPoints() == Approx(expected_sym_points));
+                    REQUIRE(symbiont->ProcessResources(0) == expected_return);
+                    REQUIRE(symbiont->GetPoints() == Approx(expected_sym_points));
                 }
-                h.Delete();
+                host.Delete();
             }
 
         }
@@ -280,9 +280,9 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
     WHEN("sym_int_val > 0") {
         double sym_int_val = 0.2;
         double host_int_val = 0.5;
-        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
-        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
-        h->AddSymbiont(s);
+        emp::Ptr<PGGHost> host = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> symbiont = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
+        host->AddSymbiont(symbiont);
 
         // double resources = 100;
         // double hostDonation = 50;
@@ -290,14 +290,14 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
         double expected_sym_points = 40; // hostDonation - hostPortion
         double expected_return = 50; // hostPortion * synergy
 
-        h->SetResInProcess(50);
+        host->SetResInProcess(50);
 
 
         THEN("Sym attempts to give benefit back"){
-            REQUIRE(s->ProcessResources(50) == expected_return);
-            REQUIRE(s->GetPoints() == expected_sym_points);
+            REQUIRE(symbiont->ProcessResources(50) == expected_return);
+            REQUIRE(symbiont->GetPoints() == expected_sym_points);
         }
-        h.Delete();
+        host.Delete();
     }
 }
 
@@ -307,17 +307,17 @@ TEST_CASE("PGGSymbiont MakeNew", "[pgg]"){
     SymConfigBase config;
 
     double host_int_val = 0.2;
-    emp::Ptr<Organism> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, host_int_val);
-    emp::Ptr<Organism> s2 = s1->MakeNew();
+    emp::Ptr<Organism> symbiont1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, host_int_val);
+    emp::Ptr<Organism> symbiont2 = symbiont1->MakeNew();
     THEN("The new symbiont has properties of the original symbiont and has 0 points and 0 age"){
-      REQUIRE(s1->GetIntVal() == s2->GetIntVal());
-      REQUIRE(s1->GetInfectionChance() == s2->GetInfectionChance());
-      REQUIRE(s1->GetDonation() == s2->GetDonation());
-      REQUIRE(s2->GetPoints() == 0);
-      REQUIRE(s2->GetAge() == 0);
+      REQUIRE(symbiont1->GetIntVal() == symbiont2->GetIntVal());
+      REQUIRE(symbiont1->GetInfectionChance() == symbiont2->GetInfectionChance());
+      REQUIRE(symbiont1->GetDonation() == symbiont2->GetDonation());
+      REQUIRE(symbiont2->GetPoints() == 0);
+      REQUIRE(symbiont2->GetAge() == 0);
       //check that the offspring is the correct class
-      REQUIRE(typeid(*s2).name() == typeid(*s1).name());
+      REQUIRE(typeid(*symbiont2).name() == typeid(*symbiont1).name());
     }
-    s1.Delete();
-    s2.Delete();
+    symbiont1.Delete();
+    symbiont2.Delete();
 }

--- a/source/test/pgg_mode_test/PGGSymbiont.test.cc
+++ b/source/test/pgg_mode_test/PGGSymbiont.test.cc
@@ -12,20 +12,22 @@ TEST_CASE("PGGSymbiont Constructor", "[pgg]") {
     double donation = 1;
 
     double int_val = 0.5;
-    PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val,donation);
+    emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
     CHECK(s->GetDonation() == donation);
     CHECK(s->GetAge() == 0);
     CHECK(s->GetPoints() == 0);
 
     donation = 2;
-    PGGSymbiont * s2 = new PGGSymbiont(random, world, &config, int_val,donation);
+    emp::Ptr<PGGSymbiont> s2 = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
     CHECK(s2->GetDonation() == 2);
     CHECK(s2->GetAge() == 0);
     CHECK(s2->GetPoints() == 0);
 
     int_val = 2;
-    REQUIRE_THROWS(new PGGSymbiont(random, world, &config, int_val) );
+    REQUIRE_THROWS(emp::NewPtr<PGGSymbiont>(random, world, &config, int_val) );
 
+    s.Delete();
+    s2.Delete();
 }
 
 TEST_CASE("PGGmutate", "[pgg]") {
@@ -39,7 +41,7 @@ TEST_CASE("PGGmutate", "[pgg]") {
         double int_val = 0;
         double donation = 0.01;
         config.MUTATION_SIZE(0.002);
-        Organism * s = new PGGSymbiont(random, world, &config, int_val,donation);
+        emp::Ptr<Organism> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val,donation);
 
         s->mutate();
 
@@ -48,6 +50,7 @@ TEST_CASE("PGGmutate", "[pgg]") {
             REQUIRE(s->GetDonation() <= 1);
             REQUIRE(s->GetDonation() >= 0);
         }
+        s.Delete();
     }
     WHEN("Mutation rate is zero") {
         double int_val = 1;
@@ -56,7 +59,7 @@ TEST_CASE("PGGmutate", "[pgg]") {
         config.HORIZ_TRANS(true);
         config.MUTATION_RATE(0);
         config.MUTATION_SIZE(0);
-        Organism * s = new PGGSymbiont(random, world, &config, int_val, donation);
+        emp::Ptr<Organism> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, donation);
 
         s->mutate();
 
@@ -64,7 +67,7 @@ TEST_CASE("PGGmutate", "[pgg]") {
         THEN("Mutation does not occur and donation value does not change") {
             REQUIRE(s->GetDonation() == donation);
         }
-
+        s.Delete();
     }
 }
 
@@ -78,8 +81,8 @@ TEST_CASE("PGGSymbiont ProcessPool", "[pgg]"){
     double sym_int_val = 0;
     double donation = 0.1;
 
-    PGGSymbiont * s = new PGGSymbiont(random, &w, &config, sym_int_val,donation);
-    PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
+    emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, &w, &config, sym_int_val,donation);
+    emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
     h->AddSymbiont(s);
 
     //double piece = 40;
@@ -89,6 +92,8 @@ TEST_CASE("PGGSymbiont ProcessPool", "[pgg]"){
 
     CHECK(s->GetPoints() == 40.4);
     CHECK(h->GetPoints() == 0);
+
+    h.Delete();
 }
 
 TEST_CASE("PGGProcess", "[pgg]") {
@@ -106,7 +111,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(140.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int add_points = 200;
         s->AddPoints(add_points);
@@ -119,6 +124,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
             int points_post_reproduction = 0;
             REQUIRE(s->GetPoints() == points_post_reproduction);
         }
+        s.Delete();
     }
 
 
@@ -129,7 +135,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(200.0);
         config.HORIZ_TRANS(true);
         config.MUTATION_SIZE(0.0);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int add_points = 50;
         s->AddPoints(add_points);
@@ -142,6 +148,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
             int points_post_reproduction = 50;
             REQUIRE(s->GetPoints() == points_post_reproduction);
         }
+        s.Delete();
     }
 
 
@@ -152,7 +159,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(80.0);
         config.HORIZ_TRANS(false);
         config.MUTATION_SIZE(0.0);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int location = 10;
         s->Process(location);
@@ -162,6 +169,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
             int points_post_reproduction = 100;
             REQUIRE(s->GetPoints() == points_post_reproduction);
         }
+        s.Delete();
     }
 
     WHEN("Horizontal transmission is false and points and points is less then sym_h_res") {
@@ -171,7 +179,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
         config.SYM_HORIZ_TRANS_RES(80.0);
         config.HORIZ_TRANS(false);
         config.MUTATION_SIZE(0.0);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, int_val, 0,points);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, int_val, 0,points);
 
         int location = 10;
         s->Process(location);
@@ -181,6 +189,7 @@ TEST_CASE("PGGProcess", "[pgg]") {
             int points_post_reproduction = 40;
             REQUIRE(s->GetPoints() == points_post_reproduction);
         }
+        s.Delete();
     }
 
 }
@@ -199,8 +208,8 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
 
         WHEN("host_int_val > 0"){
             double host_int_val = 0.2;
-            PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
-            PGGSymbiont * s = new PGGSymbiont(random, world, &config, sym_int_val);
+            emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+            emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
             h->AddSymbiont(s);
 
             // double resources = 100;
@@ -216,14 +225,15 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
                 REQUIRE(s->GetPoints() == expected_sym_points);
 
             }
+            h.Delete();
         }
 
         WHEN("host_int_val < 0 and resources are placed into defense"){
 
             WHEN("host successfully defends from symsteal"){
                 double host_int_val = -0.8;
-                PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
-                PGGSymbiont * s = new PGGSymbiont(random, world, &config, sym_int_val);
+                emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+                emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
                 h->AddSymbiont(s);
 
                 // double resources = 100;
@@ -238,12 +248,13 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
                     REQUIRE(s->ProcessResources(0) == expected_return);
                     REQUIRE(s->GetPoints() == expected_sym_points);
                 }
+                h.Delete();
             }
 
             WHEN("host fails at defense"){
                 double host_int_val = -0.5;
-                PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
-                PGGSymbiont * s = new PGGSymbiont(random, world, &config, sym_int_val);
+                emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+                emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
                 h->AddSymbiont(s);
 
                 // double resources = 100;
@@ -259,6 +270,7 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
                     REQUIRE(s->ProcessResources(0) == expected_return);
                     REQUIRE(s->GetPoints() == Approx(expected_sym_points));
                 }
+                h.Delete();
             }
 
         }
@@ -268,8 +280,8 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
     WHEN("sym_int_val > 0") {
         double sym_int_val = 0.2;
         double host_int_val = 0.5;
-        PGGHost * h = new PGGHost(random, &w, &config, host_int_val);
-        PGGSymbiont * s = new PGGSymbiont(random, world, &config, sym_int_val);
+        emp::Ptr<PGGHost> h = emp::NewPtr<PGGHost>(random, &w, &config, host_int_val);
+        emp::Ptr<PGGSymbiont> s = emp::NewPtr<PGGSymbiont>(random, world, &config, sym_int_val);
         h->AddSymbiont(s);
 
         // double resources = 100;
@@ -285,9 +297,8 @@ TEST_CASE("PGGSymbiont ProcessResources", "[pgg]"){
             REQUIRE(s->ProcessResources(50) == expected_return);
             REQUIRE(s->GetPoints() == expected_sym_points);
         }
+        h.Delete();
     }
-
-
 }
 
 TEST_CASE("PGGSymbiont makeNew", "[pgg]"){
@@ -296,8 +307,8 @@ TEST_CASE("PGGSymbiont makeNew", "[pgg]"){
     SymConfigBase config;
 
     double host_int_val = 0.2;
-    Organism * s1 = new PGGSymbiont(random, &w, &config, host_int_val);
-    Organism * s2 = s1->makeNew();
+    emp::Ptr<Organism> s1 = emp::NewPtr<PGGSymbiont>(random, &w, &config, host_int_val);
+    emp::Ptr<Organism> s2 = s1->makeNew();
     THEN("The new symbiont has properties of the original symbiont and has 0 points and 0 age"){
       REQUIRE(s1->GetIntVal() == s2->GetIntVal());
       REQUIRE(s1->GetInfectionChance() == s2->GetInfectionChance());
@@ -307,4 +318,6 @@ TEST_CASE("PGGSymbiont makeNew", "[pgg]"){
       //check that the offspring is the correct class
       REQUIRE(typeid(*s2).name() == typeid(*s1).name());
     }
+    s1.Delete();
+    s2.Delete();
 }


### PR DESCRIPTION
- make test-debug passing, 
- variable names in tests expanded (eg p -> phage), 
- some method names changed to CamelCase,
- preliminary attempts at worldSetup inheritance.