### PR TITLE
Try to sample a random neighbor in GetNeighborHost and only enumerate all positions if that fails

### DIFF
--- a/source/default_mode/SymWorld.h
+++ b/source/default_mode/SymWorld.h
@@ -370,6 +370,14 @@ public:
    * Purpose: To determine the location of a valid occupied neighboring position.
    */
   int GetNeighborHost (size_t i) {
+    // Attempt to use GetRandomNeighborPos first, since it's much faster
+    for (int i = 0; i < 3; i++) {
+      emp::WorldPosition neighbor = GetRandomNeighborPos(i);
+      if (neighbor.IsValid() && pop[neighbor.GetIndex()].Raw())
+        return neighbor.GetIndex();
+    }
+
+    // Then enumerate all occupied neighbors, in case many neighbors are unoccupied
     const emp::vector<size_t> validNeighbors = GetValidNeighborOrgIDs(i);
     if (validNeighbors.empty()) return -1;
     else {

--- a/source/default_mode/SymWorld.h
+++ b/source/default_mode/SymWorld.h
@@ -373,7 +373,7 @@ public:
     // Attempt to use GetRandomNeighborPos first, since it's much faster
     for (int i = 0; i < 3; i++) {
       emp::WorldPosition neighbor = GetRandomNeighborPos(id);
-      if (neighbor.IsValid() && neighbor.GetIndex() < GetSize() && pop[neighbor.GetIndex()].Raw())
+      if (neighbor.IsValid() && IsOccupied(neighbor))
         return neighbor.GetIndex();
     }
 

--- a/source/default_mode/SymWorld.h
+++ b/source/default_mode/SymWorld.h
@@ -369,16 +369,16 @@ public:
    *
    * Purpose: To determine the location of a valid occupied neighboring position.
    */
-  int GetNeighborHost (size_t i) {
+  int GetNeighborHost (size_t id) {
     // Attempt to use GetRandomNeighborPos first, since it's much faster
     for (int i = 0; i < 3; i++) {
-      emp::WorldPosition neighbor = GetRandomNeighborPos(i);
-      if (neighbor.IsValid() && pop[neighbor.GetIndex()].Raw())
+      emp::WorldPosition neighbor = GetRandomNeighborPos(id);
+      if (neighbor.IsValid() && neighbor.GetIndex() < GetSize() && pop[neighbor.GetIndex()].Raw())
         return neighbor.GetIndex();
     }
 
     // Then enumerate all occupied neighbors, in case many neighbors are unoccupied
-    const emp::vector<size_t> validNeighbors = GetValidNeighborOrgIDs(i);
+    const emp::vector<size_t> validNeighbors = GetValidNeighborOrgIDs(id);
     if (validNeighbors.empty()) return -1;
     else {
       int randI = GetRandom().GetUInt(0, validNeighbors.size());


### PR DESCRIPTION
This seems to improve overall performance quite a bit, and the semantics should be exactly the same since it falls back on the old method after three tries with randomly sampled neighbors. In a dense population, it will almost always succeed on the first try and avoid unnecessary computation.