### PR TITLE
Fix bugs related to calculation of modularity and diversity

### DIFF
--- a/source/native/symbulation_sgp.cc
+++ b/source/native/symbulation_sgp.cc
@@ -91,10 +91,10 @@ int symbulation_main(int argc, char *argv[]) {
     phenotype_counts_file.open(phenotype_counts_path);
     
     phenotype_counts_file << "phenotype, count, partner" << std::endl;
-    for (auto const pair : host_phenotype_map){
+    for (auto const &pair : host_phenotype_map){
       phenotype_counts_file << pair.first << " " << pair.second << " host" << std::endl;
     }
-    for (auto const pair : sym_phenotype_map){
+    for (auto const &pair : sym_phenotype_map){
       phenotype_counts_file << pair.first << " " << pair.second << " sym" << std::endl;
     }
   });

--- a/source/sgp_mode/AnalysisTools.h
+++ b/source/sgp_mode/AnalysisTools.h
@@ -83,7 +83,7 @@ bool ReturnTaskDone(size_t task_id, CPU org_cpu) {
  *of the necessary code lines to complete the given task
  *
  */
-emp::optional<emp::BitArray<100>> GetNecessaryInstructions(CPU org_cpu, size_t test_task_id) {
+std::optional<emp::BitArray<100>> GetNecessaryInstructions(CPU org_cpu, size_t test_task_id) {
   emp::Random random(-1);
   sgpl::Program<Spec> const control_program = org_cpu.GetProgram();
   sgpl::Program<Spec> test_program = control_program;
@@ -129,9 +129,9 @@ emp::optional<emp::BitArray<100>> GetNecessaryInstructions(CPU org_cpu, size_t t
  * then a (-1) is returned in the first and only position of the reduced program representation.
  *
  */
-emp::vector<emp::optional<emp::BitArray<100>>> GetReducedProgramRepresentations(CPU org_cpu) {
+emp::vector<std::optional<emp::BitArray<100>>> GetReducedProgramRepresentations(CPU org_cpu) {
   const TaskSet &all_tasks = org_cpu.state.world->GetTaskSet();
-  emp::vector<emp::optional<emp::BitArray<100>>> map_of_guides;
+  emp::vector<std::optional<emp::BitArray<100>>> map_of_guides;
 
   for (size_t j = 0; j < all_tasks.NumTasks(); ++j) {
     map_of_guides.push_back(GetNecessaryInstructions(org_cpu, j));

--- a/source/sgp_mode/AnalysisTools.h
+++ b/source/sgp_mode/AnalysisTools.h
@@ -15,6 +15,8 @@
 #include "SGPHost.h"
 #include "SGPWorld.h"
 #include "Tasks.h"
+#include "emp/base/optional.hpp"
+#include "emp/bits/BitArray.hpp"
 #include "sgpl/algorithm/execute_cpu.hpp"
 #include "sgpl/hardware/Cpu.hpp"
 #include "sgpl/library/OpLibraryCoupler.hpp"
@@ -28,6 +30,7 @@
 #include "sgpl/utility/ThreadLocalRandom.hpp"
 #include <iostream>
 #include <math.h>
+#include <optional>
 #include <set>
 
 // start of getNecessarySites methods
@@ -43,7 +46,6 @@
  *
  */
 emp::BitSet<64> ReturnTasksDone(CPU org_cpu) {
-  bool if_task_true = false;
   org_cpu.Reset();
   org_cpu.state.self_completed = {1, 1, 1, 1, 1, 1, 1, 1, 1};
 
@@ -81,23 +83,19 @@ bool ReturnTaskDone(size_t task_id, CPU org_cpu) {
  *of the necessary code lines to complete the given task
  *
  */
-emp::vector<int> GetNecessaryInstructions(CPU org_cpu, size_t test_task_id) {
+emp::optional<emp::BitArray<100>> GetNecessaryInstructions(CPU org_cpu, size_t test_task_id) {
   emp::Random random(-1);
   sgpl::Program<Spec> const control_program = org_cpu.GetProgram();
   sgpl::Program<Spec> test_program = control_program;
 
-  emp::vector<int> reduced_position_guide = {};
+  emp::BitArray<100> reduced_position_guide;
 
   bool can_do_task = ReturnTaskDone(test_task_id, org_cpu);
 
   // catches if a task cannot be done ever
   if (!can_do_task) {
-    reduced_position_guide.push_back(-1);
-    return reduced_position_guide;
-  }
-
-  if (can_do_task) {
-
+    return std::nullopt;
+  } else {
     for (size_t k = 0; k <= control_program.size() - 1; k++) {
 
       test_program[k].op_code = 0;
@@ -106,11 +104,9 @@ emp::vector<int> GetNecessaryInstructions(CPU org_cpu, size_t test_task_id) {
       can_do_task = ReturnTaskDone(test_task_id, temp_cpu);
 
       if (!can_do_task) {
-        reduced_position_guide.push_back(1);
-      }
-
-      else {
-        reduced_position_guide.push_back(0);
+        reduced_position_guide.Set(k, 1);
+      } else {
+        reduced_position_guide.Set(k, 0);
       }
 
       test_program = control_program;
@@ -133,16 +129,12 @@ emp::vector<int> GetNecessaryInstructions(CPU org_cpu, size_t test_task_id) {
  * then a (-1) is returned in the first and only position of the reduced program representation.
  *
  */
-emp::vector<emp::vector<int>> GetReducedProgramRepresentations(CPU org_cpu) {
-  CPUState condition = org_cpu.state;
-  TaskSet all_tasks = condition.world->GetTaskSet();
-  sgpl::Program<Spec> original_program = org_cpu.GetProgram();
-  emp::vector<emp::vector<int>> map_of_guides;
+emp::vector<emp::optional<emp::BitArray<100>>> GetReducedProgramRepresentations(CPU org_cpu) {
+  const TaskSet &all_tasks = org_cpu.state.world->GetTaskSet();
+  emp::vector<emp::optional<emp::BitArray<100>>> map_of_guides;
 
   for (size_t j = 0; j < all_tasks.NumTasks(); ++j) {
-    emp::vector<int> position_guide = {};
-    position_guide = GetNecessaryInstructions(org_cpu, j);
-    map_of_guides.push_back(position_guide);
+    map_of_guides.push_back(GetNecessaryInstructions(org_cpu, j));
   }
 
   return map_of_guides;

--- a/source/sgp_mode/CPU.h
+++ b/source/sgp_mode/CPU.h
@@ -109,18 +109,6 @@ public:
 
     sgpl::execute_cpu_n_cycles<Spec>(n_cycles, cpu, program, state);
   }
-  /**
-   * Input: None
-   *
-   * Output: The SignalGPLite cpu. 
-   *
-   * Purpose: 
-   */
-  sgpl::Cpu<Spec> GetCPU(){
-    return cpu;
-  }
-
-
 
   /**
    * Input: None

--- a/source/sgp_mode/DiversityAnalysis.h
+++ b/source/sgp_mode/DiversityAnalysis.h
@@ -16,17 +16,6 @@
 #include "SGPHost.h"
 #include "SGPWorld.h"
 #include "Tasks.h"
-#include "sgpl/algorithm/execute_cpu.hpp"
-#include "sgpl/hardware/Cpu.hpp"
-#include "sgpl/library/OpLibraryCoupler.hpp"
-#include "sgpl/library/prefab/ArithmeticOpLibrary.hpp"
-#include "sgpl/library/prefab/ControlFlowOpLibrary.hpp"
-#include "sgpl/operations/flow_global/Anchor.hpp"
-#include "sgpl/operations/unary/Increment.hpp"
-#include "sgpl/operations/unary/Terminal.hpp"
-#include "sgpl/program/Program.hpp"
-#include "sgpl/spec/Spec.hpp"
-#include "sgpl/utility/ThreadLocalRandom.hpp"
 #include <math.h>
 #include <set>
 

--- a/source/sgp_mode/Instructions.h
+++ b/source/sgp_mode/Instructions.h
@@ -174,11 +174,14 @@ INST(Steal, {
 INST(Reuptake, {
   uint32_t next;
   AddOrganismPoints(state, *a);
-  if(state.internalEnvironment->size() > 0){//Only gets resources if the organism has values in their internal environment
-    next = (*state.internalEnvironment)[state.internalEnvironment->size() - 1];//Takes a resource from back of internal environment vector
-    state.internalEnvironment->pop_back();//Clears out the selected resource from Internal Environment
+  if (state.internalEnvironment->size() > 0) { // Only gets resources if the organism has values in their internal environment
+    next = state.internalEnvironment->back(); // Takes a resource from back of internal environment vector
+    state.internalEnvironment->pop_back(); // Clears out the selected resource from Internal Environment
     *a = next;
     state.input_buf.push(next);
+  } else {
+    // Otherwise, reset the register to 0
+    *a = 0;
   }
 });
 

--- a/source/sgp_mode/ModularityAnalysis.h
+++ b/source/sgp_mode/ModularityAnalysis.h
@@ -43,8 +43,10 @@
  *them to a vector for GetNumSiteDist() to use
  *
  */
-emp::vector<int> GetUsefulStarts(emp::vector<emp::vector<int>> task_programs) {
-  emp::vector<int> list_of_starts = {};
+template <const size_t length>
+emp::vector<size_t>
+GetUsefulStarts(emp::vector<emp::BitArray<length>> task_programs) {
+  emp::vector<size_t> list_of_starts = {};
 
   for (size_t y = 0; y < task_programs.size(); y++) {
     for (size_t e = 0; e <= task_programs[y].size() - 1; e++) {
@@ -72,12 +74,14 @@ emp::vector<int> GetUsefulStarts(emp::vector<emp::vector<int>> task_programs) {
  *them to a vector for GetNumSiteDist() to use
  *
  */
-emp::vector<int> GetUsefulEnds(emp::vector<emp::vector<int>> task_programs) {
-  emp::vector<int> list_of_ends = {};
+template <const size_t length>
+emp::vector<size_t>
+GetUsefulEnds(emp::vector<emp::BitArray<length>> task_programs) {
+  emp::vector<size_t> list_of_ends = {};
   for (size_t y = 0; y < task_programs.size(); y++) {
     for (size_t f = task_programs[y].size(); f > 0; f--) {
-      if (task_programs[y][f-1] == 1) {
-        list_of_ends.push_back(f-1);
+      if (task_programs[y][f - 1] == 1) {
+        list_of_ends.push_back(f - 1);
         break;
       }
     }
@@ -104,7 +108,9 @@ emp::vector<int> GetUsefulEnds(emp::vector<emp::vector<int>> task_programs) {
  *of them, and returns their total amount
  *unless there are no sites the method should always return at least 2
  */
-int GetNumSites(int start_inst, int end_inst, emp::vector<int> alt_genome) {
+template <const size_t length>
+int GetNumSites(int start_inst, int end_inst,
+                emp::BitArray<length> alt_genome) {
   // for altered genome clusters
   int total_sites = 0;
 
@@ -149,27 +155,27 @@ int GetDistance(int i, int j, int length) {
  *of all the sites of the tasks it can do
  *
  */
-
-double GetPModularity(emp::vector<emp::vector<int>> task_programs) {
+template <const size_t length>
+double GetPModularity(emp::vector<emp::BitArray<length>> task_programs) {
   double all_distance = 0.0;
-  emp::vector<int> useful_starts = GetUsefulStarts(task_programs);
-  emp::vector<int> useful_ends = GetUsefulEnds(task_programs);
+  emp::vector<size_t> useful_starts = GetUsefulStarts(task_programs);
+  emp::vector<size_t> useful_ends = GetUsefulEnds(task_programs);
 
-  for (int t = 0; t < (int)task_programs.size();
+  for (size_t t = 0; t < task_programs.size();
        t++) { // loop through different tasks
 
-    emp::vector<int> program = task_programs[t];
-    int size = (int)program.size();
+    emp::BitArray<length> program = task_programs[t];
+    size_t size = program.size();
     double nSt = GetNumSites(useful_starts[t], useful_ends[t], program);
     if (nSt != 1) {
 
       double sum_distance = 0;
 
-      for (int i = useful_starts[t]; i <= useful_ends[t]; i++) {
+      for (size_t i = useful_starts[t]; i <= useful_ends[t]; i++) {
 
         if (program[i] == 1) {
 
-          for (int j = useful_starts[t]; j <= useful_ends[t]; j++) {
+          for (size_t j = useful_starts[t]; j <= useful_ends[t]; j++) {
 
             if ((i != j) && (program[j] == 1)) {
               sum_distance += GetDistance(i, j, size);
@@ -184,8 +190,8 @@ double GetPModularity(emp::vector<emp::vector<int>> task_programs) {
   }
 
   double physical_mod_val =
-      1 - (2.0 * all_distance /
-           (task_programs[0].size() * (int)task_programs.size()));
+      1 -
+      (2.0 * all_distance / (task_programs[0].size() * task_programs.size()));
   return physical_mod_val;
 }
 
@@ -201,16 +207,16 @@ double GetPModularity(emp::vector<emp::vector<int>> task_programs) {
  */
 
 double GetPMFromCPU(CPU org_cpu) {
-  emp::vector<emp::vector<int>> obtained_positions =
+  emp::vector<emp::optional<emp::BitArray<100>>> obtained_positions =
       GetReducedProgramRepresentations(org_cpu);
 
-  emp::vector<emp::vector<int>> filtered_obtained_positions;
-  for (int i = 0; i < (int)obtained_positions.size(); i++) {
-    if (obtained_positions[i].size() != 1) {
-      filtered_obtained_positions.push_back(obtained_positions[i]);
+  emp::vector<emp::BitArray<100>> filtered_obtained_positions;
+  for (size_t i = 0; i < obtained_positions.size(); i++) {
+    if (obtained_positions[i].has_value()) {
+      filtered_obtained_positions.push_back(*obtained_positions[i]);
     }
   }
-  if ((int)filtered_obtained_positions.size() == 0) {
+  if (filtered_obtained_positions.size() == 0) {
     return -1.0;
   }
 
@@ -234,17 +240,16 @@ double GetPMFromCPU(CPU org_cpu) {
  *of all the sites of the tasks it can do
  *
  */
-
-double GetFModularity(emp::vector<emp::vector<int>> task_programs) {
-  int tasks_count = (int)task_programs.size();
-  int length = task_programs[0].size();
+template <const size_t length>
+double GetFModularity(emp::vector<emp::BitArray<length>> task_programs) {
+  size_t tasks_count = task_programs.size();
   double functional_mod_val = 0.0;
   double sum = 0.0; // sum is everything on the numerator
-  for (int i = 0; i < (int)task_programs.size(); i++) {   // trait a
-    for (int j = 0; j < (int)task_programs.size(); j++) { // trait b
+  for (size_t i = 0; i < task_programs.size(); i++) {   // trait a
+    for (size_t j = 0; j < task_programs.size(); j++) { // trait b
       if (i != j) {
-        emp::vector<int> current_program = task_programs[i];
-        for (int k = 0; k < (int)current_program.size(); k++) {
+        emp::BitArray<length> current_program = task_programs[i];
+        for (size_t k = 0; k < current_program.size(); k++) {
           if (current_program[k] == 1) {
             sum += (1 - task_programs[j][k]);
             // task_programs[j][k] is the M(s,b) in the paper,
@@ -270,13 +275,13 @@ double GetFModularity(emp::vector<emp::vector<int>> task_programs) {
  *
  */
 double GetFMFromCPU(CPU org_cpu) {
-  emp::vector<emp::vector<int>> obtained_positions =
+  emp::vector<emp::optional<emp::BitArray<100>>> obtained_positions =
       GetReducedProgramRepresentations(org_cpu);
 
-  emp::vector<emp::vector<int>> filtered_obtained_positions;
-  for (int i = 0; i < (int)obtained_positions.size(); i++) {
-    if (obtained_positions[i].size() != 1) {
-      filtered_obtained_positions.push_back(obtained_positions[i]);
+  emp::vector<emp::BitArray<100>> filtered_obtained_positions;
+  for (size_t i = 0; i < obtained_positions.size(); i++) {
+    if (obtained_positions[i].has_value()) {
+      filtered_obtained_positions.push_back(*obtained_positions[i]);
     }
   }
 

--- a/source/sgp_mode/ModularityAnalysis.h
+++ b/source/sgp_mode/ModularityAnalysis.h
@@ -207,7 +207,7 @@ double GetPModularity(emp::vector<emp::BitArray<length>> task_programs) {
  */
 
 double GetPMFromCPU(CPU org_cpu) {
-  emp::vector<emp::optional<emp::BitArray<100>>> obtained_positions =
+  emp::vector<std::optional<emp::BitArray<100>>> obtained_positions =
       GetReducedProgramRepresentations(org_cpu);
 
   emp::vector<emp::BitArray<100>> filtered_obtained_positions;
@@ -275,7 +275,7 @@ double GetFModularity(emp::vector<emp::BitArray<length>> task_programs) {
  *
  */
 double GetFMFromCPU(CPU org_cpu) {
-  emp::vector<emp::optional<emp::BitArray<100>>> obtained_positions =
+  emp::vector<std::optional<emp::BitArray<100>>> obtained_positions =
       GetReducedProgramRepresentations(org_cpu);
 
   emp::vector<emp::BitArray<100>> filtered_obtained_positions;

--- a/source/test/sgp_mode_test/AnalysisTools.test.cc
+++ b/source/test/sgp_mode_test/AnalysisTools.test.cc
@@ -66,10 +66,10 @@ TEST_CASE("GetNecessaryInstructions", "[sgp]") {
     WHEN("The only task is the basic Not-genome") {
       size_t test_id = 0;
 
-      emp::vector<int> program_position_guide =
+      emp::optional<emp::BitArray<100>> program_position_guide =
           GetNecessaryInstructions(test_sample->GetCPU(), test_id);
 
-      emp::vector<int> expected_vector = {
+      emp::BitArray<100> expected_vector = {
           1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -99,25 +99,25 @@ TEST_CASE("GetReducedProgramRepresentations", "[sgp]") {
     config.POP_SIZE(pop_size);
 
     WHEN("The only task is the basic Not-genome") {
-      emp::vector<int> expected_vector = {
+      emp::BitArray<100> expected_vector = {
           1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0};
 
-      emp::vector<emp::vector<int>> test_map = {};
       emp::Ptr<SGPHost> test_sample =
           emp::NewPtr<SGPHost>(&random, &world, &config);
 
-      test_map = GetReducedProgramRepresentations(test_sample->GetCPU());
-      emp::vector<emp::vector<int>> expected_map = {
-          expected_vector, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}};
-    
-        THEN("There are 4 needed code sites necessary to perform the Not-task "
-             "and the genome cannot perform any other tasks") {
-          REQUIRE(test_map == expected_map);
-        }
+      emp::vector<emp::optional<emp::BitArray<100>>> test_map =
+          GetReducedProgramRepresentations(test_sample->GetCPU());
+      emp::vector<emp::optional<emp::BitArray<100>>> expected_map = {
+          expected_vector, {}, {}, {}, {}, {}, {}, {}, {}};
+
+      THEN("There are 4 needed code sites necessary to perform the Not-task "
+           "and the genome cannot perform any other tasks") {
+        REQUIRE(test_map == expected_map);
+      }
     }
   }
 }

--- a/source/test/sgp_mode_test/AnalysisTools.test.cc
+++ b/source/test/sgp_mode_test/AnalysisTools.test.cc
@@ -66,7 +66,7 @@ TEST_CASE("GetNecessaryInstructions", "[sgp]") {
     WHEN("The only task is the basic Not-genome") {
       size_t test_id = 0;
 
-      emp::optional<emp::BitArray<100>> program_position_guide =
+      std::optional<emp::BitArray<100>> program_position_guide =
           GetNecessaryInstructions(test_sample->GetCPU(), test_id);
 
       emp::BitArray<100> expected_vector = {
@@ -109,9 +109,11 @@ TEST_CASE("GetReducedProgramRepresentations", "[sgp]") {
       emp::Ptr<SGPHost> test_sample =
           emp::NewPtr<SGPHost>(&random, &world, &config);
 
-      emp::vector<emp::optional<emp::BitArray<100>>> test_map =
+      // These need to be std::vectors because emp::vectors don't play well with
+      // Catch's magic for printing out the expanded `==` expression
+      std::vector<std::optional<emp::BitArray<100>>> test_map =
           GetReducedProgramRepresentations(test_sample->GetCPU());
-      emp::vector<emp::optional<emp::BitArray<100>>> expected_map = {
+      std::vector<std::optional<emp::BitArray<100>>> expected_map = {
           expected_vector, {}, {}, {}, {}, {}, {}, {}, {}};
 
       THEN("There are 4 needed code sites necessary to perform the Not-task "

--- a/source/test/sgp_mode_test/SGPModularity.test.cc
+++ b/source/test/sgp_mode_test/SGPModularity.test.cc
@@ -21,24 +21,24 @@ TEST_CASE("GetUsefulStarts", "[sgp]") {
         "actual genome that is either"
         "necessary to perform the designated task or not necessary to perform "
         "the task, respectively") {
-    emp::vector<int> needed_code_sites_a = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
-    emp::vector<int> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
-    emp::vector<int> needed_code_sites_c = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
-    emp::vector<int> needed_code_sites_d = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    emp::vector<int> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_a = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
+    emp::BitArray<20> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
+    emp::BitArray<20> needed_code_sites_c = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
+    emp::BitArray<20> needed_code_sites_d = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    emp::BitArray<20> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-    emp::vector<emp::vector<int>> needed_code_sites = {
+    emp::vector<emp::BitArray<20>> needed_code_sites = {
         needed_code_sites_a, needed_code_sites_b, needed_code_sites_c,
         needed_code_sites_d, needed_code_sites_e};
 
-    emp::vector<int> calc_useful_starts = GetUsefulStarts(needed_code_sites);
-    emp::vector<int> true_useful_starts = {0, 6, (int)needed_code_sites_c.size() - 5,
-                                           (int)needed_code_sites_d.size() - 1};
+    emp::vector<size_t> calc_useful_starts = GetUsefulStarts(needed_code_sites);
+    emp::vector<size_t> true_useful_starts = {
+        0, 6, needed_code_sites_c.size() - 5, needed_code_sites_d.size() - 1};
 
     REQUIRE(calc_useful_starts == true_useful_starts);
   }
@@ -49,24 +49,24 @@ TEST_CASE("GetUsefulEnds", "[sgp]") {
         "actual genome that is either"
         "necessary to perform the designated task or not necessary to perform "
         "the task, respectively") {
-    emp::vector<int> needed_code_sites_a = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
-    emp::vector<int> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_c = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 1, 0, 0, 1, 1, 1, 0, 0};
-    emp::vector<int> needed_code_sites_d = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_a = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
+    emp::BitArray<20> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_c = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 1, 0, 0, 1, 1, 1, 0, 0};
+    emp::BitArray<20> needed_code_sites_d = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-    emp::vector<emp::vector<int>> needed_code_sites = {
+    emp::vector<emp::BitArray<20>> needed_code_sites = {
         needed_code_sites_a, needed_code_sites_b, needed_code_sites_c,
         needed_code_sites_d, needed_code_sites_e};
 
-    emp::vector<int> calc_useful_ends = GetUsefulEnds(needed_code_sites);
-    emp::vector<int> true_useful_ends = {(int)needed_code_sites_a.size() - 1, 9,
-                                         (int)needed_code_sites_c.size() - 3, 0};
+    emp::vector<size_t> calc_useful_ends = GetUsefulEnds(needed_code_sites);
+    emp::vector<size_t> true_useful_ends = {needed_code_sites_a.size() - 1, 9,
+                                            needed_code_sites_c.size() - 3, 0};
 
     REQUIRE(calc_useful_ends == true_useful_ends);
   }
@@ -79,15 +79,16 @@ TEST_CASE("GetNumSites", "[sgp]") {
         "the task, respectively") {
 
     WHEN("there are necessary sites") {
-      emp::vector<int> needed_code_sites = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
+      emp::BitArray<100> needed_code_sites = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                              0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
       int site_count = GetNumSites(0, 19, needed_code_sites);
 
       THEN("GetNumsites returns a number > 0") { REQUIRE(site_count == 10); }
     }
 
     WHEN("there are no necessary sites") {
-      emp::vector<int> needed_code_sites = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+      emp::BitArray<100> needed_code_sites = {0, 0, 0, 0, 0, 0,
+                                              0, 0, 0, 0, 0, 0};
       int site_count = GetNumSites(0, 11, needed_code_sites);
 
       THEN("GetNumsites returns 0") { REQUIRE(site_count == 0); }
@@ -145,23 +146,24 @@ TEST_CASE("GetPModularity", "[sgp]") {
         "actual genome that is either"
         "necessary to perform the designated task or not necessary to perform "
         "the task, respectively") {
-    emp::vector<int> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_c = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_d = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    emp::vector<int> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_c = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_d = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    emp::BitArray<20> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-    emp::vector<emp::vector<int>> needed_code_sites = {needed_code_sites_b};
-
+    emp::vector<emp::BitArray<20>> needed_code_sites = {needed_code_sites_b};
 
     WHEN("The only reduced program that can do a task is needed_code_sites_b") {
       double test_phys_mod_a = GetPModularity(needed_code_sites);
       double found_value_a = 0.8333333;
 
-      THEN("The physical modularity will be high") { REQUIRE(test_phys_mod_a == Approx(found_value_a)); }
+      THEN("The physical modularity will be high") {
+        REQUIRE(test_phys_mod_a == Approx(found_value_a));
+      }
     }
 
     needed_code_sites.push_back(needed_code_sites_d);
@@ -169,8 +171,10 @@ TEST_CASE("GetPModularity", "[sgp]") {
 
       double test_phys_mod_b = GetPModularity(needed_code_sites);
       double found_value_b = 0.8666666667;
-      THEN("The physical modularity will inc as compared to first case due to n_c_s_d")
-       { REQUIRE(test_phys_mod_b == Approx(found_value_b)); }
+      THEN("The physical modularity will inc as compared to first case due to "
+           "n_c_s_d") {
+        REQUIRE(test_phys_mod_b == Approx(found_value_b));
+      }
     }
 
     needed_code_sites.pop_back();
@@ -180,7 +184,9 @@ TEST_CASE("GetPModularity", "[sgp]") {
       double test_phys_mod_c = GetPModularity(needed_code_sites);
       double found_value_c = 1.0;
 
-      THEN("There is perfect physical modularity") { REQUIRE(test_phys_mod_c == Approx(found_value_c)); }
+      THEN("There is perfect physical modularity") {
+        REQUIRE(test_phys_mod_c == Approx(found_value_c));
+      }
     }
 
     needed_code_sites.pop_back();
@@ -189,7 +195,9 @@ TEST_CASE("GetPModularity", "[sgp]") {
       double test_phys_mod_d = GetPModularity(needed_code_sites);
       double found_value_d = 0.0;
 
-      THEN("There is no physical modularity") { REQUIRE(test_phys_mod_d == Approx(found_value_d)); }
+      THEN("There is no physical modularity") {
+        REQUIRE(test_phys_mod_d == Approx(found_value_d));
+      }
     }
   }
 }
@@ -214,7 +222,9 @@ TEST_CASE("GetPMFromCPU", "[sgp]") {
     double expected_phys_mod = .94;
     double test_phys_mod = GetPMFromCPU(test_sample->GetCPU());
 
-    THEN("Physical modularity is extremely high") { REQUIRE(Approx(expected_phys_mod) == test_phys_mod); }
+    THEN("Physical modularity is extremely high") {
+      REQUIRE(Approx(expected_phys_mod) == test_phys_mod);
+    }
   }
 
   WHEN("It is a random genome and the host can do no task") {
@@ -233,7 +243,9 @@ TEST_CASE("GetPMFromCPU", "[sgp]") {
     double expected_phys_mod = -1.0;
     double test_phys_mod = GetPMFromCPU(test_sample->GetCPU());
 
-    THEN("The method cannot take the program's physical modularity") { REQUIRE(Approx(expected_phys_mod) == test_phys_mod); }
+    THEN("The method cannot take the program's physical modularity") {
+      REQUIRE(Approx(expected_phys_mod) == test_phys_mod);
+    }
   }
 
   WHEN("using logic tasks") {
@@ -256,32 +268,32 @@ TEST_CASE("GetPMFromCPU", "[sgp]") {
       ProgramBuilder builder;
       builder.AddNand();
       sgpl::Program<Spec> test_program = builder.Build(length);
-      CPU temp_cpu =
-          CPU(test_sample->GetCPU().state.host,
-              test_sample->GetCPU().state.world, test_program);
+      CPU temp_cpu = CPU(test_sample->GetCPU().state.host,
+                         test_sample->GetCPU().state.world, test_program);
       test_sample->GetCPU() = temp_cpu;
 
       double expected_phys_mod = .94666667;
       double test_phys_mod = GetPMFromCPU(test_sample->GetCPU());
 
-      THEN("The program has high physical modularity") 
-      { REQUIRE(Approx(expected_phys_mod) == test_phys_mod); }
+      THEN("The program has high physical modularity") {
+        REQUIRE(Approx(expected_phys_mod) == test_phys_mod);
+      }
     }
 
     WHEN("The genome is one of the other logic tasks only") {
       ProgramBuilder builder;
       builder.AddOrn();
       sgpl::Program<Spec> test_program = builder.Build(length);
-      CPU temp_cpu =
-          CPU(test_sample->GetCPU().state.host,
-              test_sample->GetCPU().state.world,test_program);
+      CPU temp_cpu = CPU(test_sample->GetCPU().state.host,
+                         test_sample->GetCPU().state.world, test_program);
       test_sample->GetCPU() = temp_cpu;
 
       double expected_phys_mod = .9466667;
       double test_phys_mod = GetPMFromCPU(test_sample->GetCPU());
 
-      THEN("The physical modularity will be lower than the basic tasks'") 
-      { REQUIRE(Approx(expected_phys_mod) == test_phys_mod); }
+      THEN("The physical modularity will be lower than the basic tasks'") {
+        REQUIRE(Approx(expected_phys_mod) == test_phys_mod);
+      }
     }
   }
 }
@@ -291,27 +303,29 @@ TEST_CASE("GetFModularity", "[sgp]") {
         "actual genome that is either"
         "necessary to perform the designated task or not necessary to perform "
         "the task, respectively") {
-    emp::vector<int> needed_code_sites_a = {0, 0, 0, 0, 1, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
-    emp::vector<int> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_c = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_d = {1, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 1, 1, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    emp::vector<int> needed_code_sites_f = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_a = {0, 0, 0, 0, 1, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 1, 1, 1, 0, 1};
+    emp::BitArray<20> needed_code_sites_b = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_c = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_d = {1, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_e = {0, 0, 0, 0, 0, 0, 0, 1, 1, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    emp::BitArray<20> needed_code_sites_f = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-    emp::vector<emp::vector<int>> needed_code_sites = {needed_code_sites_b,
-                                                       needed_code_sites_e};
+    emp::vector<emp::BitArray<20>> needed_code_sites = {needed_code_sites_b,
+                                                        needed_code_sites_e};
 
     WHEN("There is partial overlap between the two reduced programs") {
       double test_funct_mod_a = GetFModularity(needed_code_sites);
       double found_value_a = 0.05;
 
-      THEN("There is low functional modularity") { REQUIRE(test_funct_mod_a == Approx(found_value_a)); }
+      THEN("There is low functional modularity") {
+        REQUIRE(test_funct_mod_a == Approx(found_value_a));
+      }
     }
     // change to conceptual framework and add thens
     needed_code_sites.pop_back();
@@ -320,14 +334,18 @@ TEST_CASE("GetFModularity", "[sgp]") {
       double test_funct_mod_b = GetFModularity(needed_code_sites);
       double found_value_b = 0.15;
 
-      THEN("There is high functional modularity") { REQUIRE(test_funct_mod_b == Approx(found_value_b)); }
+      THEN("There is high functional modularity") {
+        REQUIRE(test_funct_mod_b == Approx(found_value_b));
+      }
     }
     needed_code_sites.push_back(needed_code_sites_d);
     WHEN("There are more than 2 succesful genomes, partial overlap") {
       double test_funct_mod_c = GetFModularity(needed_code_sites);
       double found_value_c = 0.1;
 
-      THEN("There is medium functional modularity") { REQUIRE(test_funct_mod_c == Approx(found_value_c)); }
+      THEN("There is medium functional modularity") {
+        REQUIRE(test_funct_mod_c == Approx(found_value_c));
+      }
     }
 
     needed_code_sites.pop_back();
@@ -341,7 +359,9 @@ TEST_CASE("GetFModularity", "[sgp]") {
       double test_funct_mod_d = GetFModularity(needed_code_sites);
       double found_value_d = 0.0;
 
-      THEN("The functional modularity is 0.0") { REQUIRE(test_funct_mod_d == Approx(found_value_d)); }
+      THEN("The functional modularity is 0.0") {
+        REQUIRE(test_funct_mod_d == Approx(found_value_d));
+      }
     }
   }
 }
@@ -368,13 +388,15 @@ TEST_CASE("GetFMFromCPU", "[sgp]") {
     builder.AddNand();
     builder.AddNot();
     sgpl::Program<Spec> test_program = builder.Build(length);
-    CPU temp_cpu =
-        CPU(test_sample->GetCPU().state.host, test_sample->GetCPU().state.world,test_program);
+    CPU temp_cpu = CPU(test_sample->GetCPU().state.host,
+                       test_sample->GetCPU().state.world, test_program);
     test_sample->GetCPU() = temp_cpu;
 
     double expected_phys_mod = 0.015;
     double test_phys_mod = GetFMFromCPU(test_sample->GetCPU());
 
-    THEN("Functional Modularity is very low") { REQUIRE(Approx(expected_phys_mod) == test_phys_mod); }
+    THEN("Functional Modularity is very low") {
+      REQUIRE(Approx(expected_phys_mod) == test_phys_mod);
+    }
   }
 }

--- a/source/test/sgp_mode_test/SGPModularity.test.cc
+++ b/source/test/sgp_mode_test/SGPModularity.test.cc
@@ -229,6 +229,8 @@ TEST_CASE("GetPMFromCPU", "[sgp]") {
 
   WHEN("It is a random genome and the host can do no task") {
     emp::Random random(5);
+    // It happens that using the default seed here accidentally completes NOT
+    sgpl::tlrand.Get().ResetSeed(5);
     SymConfigBase config;
     config.RANDOM_ANCESTOR(true);
     int world_size = 1;


### PR DESCRIPTION
The `BitArray` change was originally for performance (we were allocating a length-100 vector of integers which were all 0 or 1, it could just be two 64-bit integers instead) but the segfault was also fixed incidentally by that change, it could also have been done without changing all the types. The other change with the reuptake instruction stops organisms from simply outputting the same value over and over again and getting a reward every time, which they had been doing before and which makes calculating phenotypes essentially impossible since the task completions are just relying on certain values being in their registers.