### PR TITLE
Sgp organism counts data file

### DIFF
--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -9,12 +9,13 @@
 void SGPWorld::CreateDataFiles() {
   std::string file_ending =
       "_SEED" + std::to_string(my_config->SEED()) + ".data";
-  // SGP mode doesn't need int val files, and they have significant performance
-  // overhead. Only the transmission file needs to be created for this mode.
+  // track the number of each organism type
   SetUpOrgCountFile(my_config->FILE_PATH() + "OrganismCounts" +
     my_config->FILE_NAME() + file_ending)
     .SetTimingRepeat(my_config->DATA_INT());
-  
+
+  // SGP mode doesn't need int val files, and they have significant performance
+  // overhead. Only the transmission file needs to be created for this mode.  
   SetUpTransmissionFile(my_config->FILE_PATH() + "TransmissionRates" +
                         my_config->FILE_NAME() + file_ending)
       .SetTimingRepeat(my_config->DATA_INT());

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -11,6 +11,10 @@ void SGPWorld::CreateDataFiles() {
       "_SEED" + std::to_string(my_config->SEED()) + ".data";
   // SGP mode doesn't need int val files, and they have significant performance
   // overhead. Only the transmission file needs to be created for this mode.
+  SetUpOrgCountFile(my_config->FILE_PATH() + "OrganismCounts" +
+    my_config->FILE_NAME() + file_ending)
+    .SetTimingRepeat(my_config->DATA_INT());
+  
   SetUpTransmissionFile(my_config->FILE_PATH() + "TransmissionRates" +
                         my_config->FILE_NAME() + file_ending)
       .SetTimingRepeat(my_config->DATA_INT());
@@ -29,6 +33,38 @@ void SGPWorld::CreateDataFiles() {
                                 my_config->FILE_NAME() + file_ending)
         .SetTimingRepeat(my_config->DATA_INT());
   }
+}
+
+
+/**
+ * Input: The address of the string representing the file to be
+ * created's name
+ *
+ * Output: The address of the DataFile that has been created.
+ *
+ * Purpose: To set up the file that will be used to track 
+ * organism counts in the world.
+ *  This includes: (1) the host count, (2) the hosted symbiont
+ * count, and (2b) the free living symbiont count, if free living
+ * symbionts are permitted.
+ */
+emp::DataFile &SGPWorld::SetUpOrgCountFile(const std::string &filename) {
+  auto& file = SetupFile(filename);
+  auto& host_count = GetHostCountDataNode();
+  auto& endo_sym_count = GetCountHostedSymsDataNode();
+  
+  file.AddVar(update, "update", "Update");
+  file.AddTotal(host_count, "count", "Total number of hosts");
+  file.AddTotal(endo_sym_count, "hosted_syms", "Total number of syms in a host");
+  
+  if (my_config->FREE_LIVING_SYMS()) {
+    auto& free_sym_count = GetCountFreeSymsDataNode();
+    file.AddTotal(free_sym_count, "free_syms", "Total number of free syms");
+  }
+
+  file.PrintHeaderKeys();
+  
+  return file;
 }
 
 emp::DataFile &SGPWorld::SetupTasksFile(const std::string &filename) {

--- a/source/sgp_mode/SGPWorld.h
+++ b/source/sgp_mode/SGPWorld.h
@@ -135,6 +135,7 @@ public:
   SyncDataMonitor<double> &GetSymEarnedDataNode();
   void SetupTasksNodes();
 
+  emp::DataFile &SetUpOrgCountFile(const std::string &filename);
   emp::DataFile &SetupSymDonatedFile(const std::string &filename);
   emp::DataFile &SetupTasksFile(const std::string &filename);
   emp::DataFile &SetupHostSquareFrequencyFile(const std::string &filename);


### PR DESCRIPTION
Adds a data file that stores total host and symbiont counts per update; if free living symbionts are permitted, they are also counted and written to the data file.