### PR TITLE
SGP ectosymbiosis

### DIFF
--- a/source/Organism.h
+++ b/source/Organism.h
@@ -239,5 +239,10 @@ class Organism {
     std::cout << "ProcessPool called from Organism" << std::endl;
     throw "Organism method called!";}
 
+
+  // SGPSymbiont functions
+  virtual void LinkEctoHost(int pos) {
+    std::cout << "LinkEctoHost called from Organism" << std::endl;
+    throw "Organism method called!";}
 };
 #endif

--- a/source/sgp_mode/Instructions.h
+++ b/source/sgp_mode/Instructions.h
@@ -136,9 +136,35 @@ INST(SharedIO, {
 });
 INST(Donate, {
   if (state.world->GetConfig()->DONATION_STEAL_INST()) {
-    if (state.organism->IsHost() || state.organism->GetHost() == nullptr)
+    // exit if org is a host or if it's a free living sym and ecto is off
+    if (state.organism->IsHost() || !(state.organism->GetHost() == nullptr && state.world->GetConfig()->ECTOSYMBIOSIS()))
       return;
-    if (emp::Ptr<Organism> host = state.organism->GetHost()) {
+
+    // get the sym's host
+    emp::Ptr<Organism> host = state.organism->GetHost();
+
+    // ecto link
+    emp::Ptr<emp::BitSet<64>> orig_used_resources;
+    emp::Ptr<emp::vector<size_t>> orig_shared_available_dependencies;
+    emp::Ptr<emp::vector<uint32_t>> orig_internal_environment;
+    bool linked = false;
+    int pop_index = state.location.GetPopID();
+    if (state.world->IsOccupied(pop_index) && host == nullptr) {
+      // set the working host to be the parallel host
+      host = state.world->GetPop()[pop_index];
+      if (host->HasSym() && state.world->GetConfig()->ECTOSYMBIOTIC_IMMUNITY()) return;
+
+      // store old sym env variables
+      orig_used_resources = state.used_resources;
+      orig_shared_available_dependencies = state.shared_available_dependencies;
+      orig_internal_environment = state.internalEnvironment;
+
+      // set environment variables to that of the host's
+      state.organism->LinkEctoHost(pop_index);
+      linked = true;
+    }
+
+    if (host) {
       // Donate 20% of the total points of the symbiont-host system
       // This way, a sym can donate e.g. 40 or 60 percent of their points in a
       // couple of instructions
@@ -151,13 +177,49 @@ INST(Donate, {
                       (1.0 - state.world->GetConfig()->DONATE_PENALTY()));
       state.organism->AddPoints(-to_donate);
     }
+
+    // ecto unlink 
+    if (linked) {
+      // state.org->Host is still nullptr; it's just the variable "host" that was 
+      // relinked to the parallel host
+      state.used_resources = orig_used_resources;
+      state.shared_available_dependencies = orig_shared_available_dependencies;
+      state.internalEnvironment = orig_internal_environment;
+    }
   }
 });
+
 INST(Steal, {
   if (state.world->GetConfig()->DONATION_STEAL_INST()) {
-    if (state.organism->IsHost() || state.organism->GetHost() == nullptr)
+    // exit if org is a host or if it's a free living sym and ecto is off
+    if (state.organism->IsHost() || !(state.organism->GetHost() == nullptr && state.world->GetConfig()->ECTOSYMBIOSIS()))
       return;
-    if (emp::Ptr<Organism> host = state.organism->GetHost()) {
+
+    // get the sym's host
+    emp::Ptr<Organism> host = state.organism->GetHost();
+
+    // ecto link
+    emp::Ptr<emp::BitSet<64>> orig_used_resources;
+    emp::Ptr<emp::vector<size_t>> orig_shared_available_dependencies;
+    emp::Ptr<emp::vector<uint32_t>> orig_internal_environment;
+    bool linked = false;
+    int pop_index = state.location.GetPopID();
+    if (state.world->IsOccupied(pop_index) && host == nullptr) {
+      // set the working host to be the parallel host
+      host = state.world->GetPop()[pop_index];
+      if (host->HasSym() && state.world->GetConfig()->ECTOSYMBIOTIC_IMMUNITY()) return;
+
+      // store old sym env variables
+      orig_used_resources = state.used_resources;
+      orig_shared_available_dependencies = state.shared_available_dependencies;
+      orig_internal_environment = state.internalEnvironment;
+
+      // set environment variables to that of the host's
+      state.organism->LinkEctoHost(pop_index);
+      linked = true;
+    }
+
+    if (host) {
       // Steal 20% of the total points of the symbiont-host system
       // This way, a sym can steal e.g. 40 or 60 percent of the host's points in
       // a couple of instructions
@@ -170,6 +232,15 @@ INST(Steal, {
       // 10% of the stolen resources are lost
       state.organism->AddPoints(
           to_steal * (1.0 - state.world->GetConfig()->STEAL_PENALTY()));
+    }
+
+    // ecto unlink 
+    if (linked) {
+      // state.org->Host is still nullptr; it's just the variable "host" that was 
+      // relinked to the parallel host
+      state.used_resources = orig_used_resources;
+      state.shared_available_dependencies = orig_shared_available_dependencies;
+      state.internalEnvironment = orig_internal_environment;
     }
   }
 });

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -85,13 +85,16 @@ public:
   void SetHost(emp::Ptr<Organism> host) {
     Symbiont::SetHost(host);
     if (my_host) {
+      if (cpu.state.used_resources) { cpu.state.used_resources.Delete(); }
+      if (cpu.state.shared_available_dependencies) {
+        cpu.state.shared_available_dependencies.Delete(); }
+      if (cpu.state.internalEnvironment) { cpu.state.internalEnvironment.Delete(); }
+
       cpu.state.used_resources =
         host.DynamicCast<SGPHost>()->GetCPU().state.used_resources;
-    cpu.state.shared_available_dependencies =
-        host.DynamicCast<SGPHost>()
-            ->GetCPU()
-            .state.shared_available_dependencies;
-    cpu.state.internalEnvironment =
+      cpu.state.shared_available_dependencies =
+        host.DynamicCast<SGPHost>()->GetCPU().state.shared_available_dependencies;
+      cpu.state.internalEnvironment =
         host.DynamicCast<SGPHost>()->GetCPU().state.internalEnvironment;
     }
   }

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -6,6 +6,7 @@
 #include "SGPHost.h"
 #include "SGPWorld.h"
 #include "emp/Evolve/World_structure.hpp"
+#include "SGPHost.h"
 
 class SGPSymbiont : public Symbiont {
 private:
@@ -107,6 +108,24 @@ public:
    * Purpose: Allows accessing the symbiont's CPU.
    */
   CPU &GetCPU() { return cpu; }
+
+  /**
+   * Input: The index of the ecto host to be linked with.
+   *
+   * Output: None.
+   *
+   * Purpose: Sets the organism's internal environment up for ectosymbiosis
+   */
+  void LinkEctoHost(int pos) {
+    emp::Ptr<Organism> host = my_world->GetPop()[pos];
+
+    cpu.state.used_resources =
+      host.DynamicCast<SGPHost>()->GetCPU().state.used_resources;
+    cpu.state.shared_available_dependencies =
+      host.DynamicCast<SGPHost>()->GetCPU().state.shared_available_dependencies;
+    cpu.state.internalEnvironment =
+      host.DynamicCast<SGPHost>()->GetCPU().state.internalEnvironment;
+  }
 
   /**
    * Input: The location of the symbiont, which includes the symbiont's position


### PR DESCRIPTION
- fixing a memory issue Anya pointed out from PR196 
- implementing basic ectosymbiosis; at the start of "steal" and "donate," free-living symbionts with parallel hosts who are open to ectosymbiosis "link" to those hosts, and at the end of such instructions they "unlink," so that other free-living functions (e.g. "infect") can proceed unimpeded. 