### PR TITLE
Infection and FLS birth data nodes

### DIFF
--- a/source/default_mode/DataNodes.h
+++ b/source/default_mode/DataNodes.h
@@ -155,6 +155,8 @@ emp::DataFile & SymWorld::SetUpFreeLivingSymFile(const std::string & filename){
   auto & node7 = GetSymInfectChanceDataNode(); //infect chance
   auto & node8 = GetFreeSymInfectChanceDataNode();
   auto & node9 = GetHostedSymInfectChanceDataNode();
+  auto & node10 = GetInfectionAttemptCount(); //infection rate
+  auto & node11 = GetInfectionSuccessCount();
 
   file.AddVar(update, "update", "Update");
 
@@ -173,6 +175,10 @@ emp::DataFile & SymWorld::SetUpFreeLivingSymFile(const std::string & filename){
   file.AddMean(node7, "mean_infectchance", "Average symbiont infection chance");
   file.AddMean(node8, "mean_freeinfectchance", "Average free symbiont infection chance");
   file.AddMean(node9, "mean_hostedinfectchance", "Average hosted symbiont infection chance");
+
+  //infection rate
+  file.AddTotal(node10, "attempted_infections", "Number of attempted infections of a host by a symbiont since last recorded", true);
+  file.AddTotal(node11, "successful_infections", "Number of successful infections of a host by a symbiont since last recorded", true);
 
   file.PrintHeaderKeys();
 
@@ -610,6 +616,38 @@ emp::DataMonitor<int>& SymWorld::GetVerticalTransmissionAttemptCount() {
     data_node_attempts_verttrans.New();
   }
   return *data_node_attempts_verttrans;
+}
+
+/**
+ * Input: None
+ *
+ * Output: The DataMonitor<int>& that has the information representing
+ * how many attempts were made by a symbiont to infect a host.
+ *
+ * Purpose: To retrieve the data node that is tracking the
+ * number of attempted symbiont infections of a host.
+ */
+emp::DataMonitor<int>& SymWorld::GetInfectionAttemptCount() {
+  if (!data_node_attempts_infection) {
+    data_node_attempts_infection.New();
+  }
+  return *data_node_attempts_infection;
+}
+
+/**
+ * Input: None
+ *
+ * Output: The DataMonitor<int>& that has the information representing
+ * how many successful attempts were made by a symbiont to infect a host.
+ *
+ * Purpose: To retrieve the data node that is tracking the
+ * number of successful symbiont infections of a host.
+ */
+emp::DataMonitor<int>& SymWorld::GetInfectionSuccessCount() {
+  if (!data_node_successes_infection) {
+    data_node_successes_infection.New();
+  }
+  return *data_node_successes_infection;
 }
 
 #endif

--- a/source/default_mode/DataNodes.h
+++ b/source/default_mode/DataNodes.h
@@ -36,34 +36,34 @@ void SymWorld::CreateDataFiles(){
  */
 emp::DataFile & SymWorld::SetupSymIntValFile(const std::string & filename) {
   auto & file = SetupFile(filename);
-  auto & node = GetSymIntValDataNode();
-  auto & node1 = GetSymCountDataNode();
+  auto & sym_intval_node = GetSymIntValDataNode();
+  auto & sym_count_node = GetSymCountDataNode();
 
   file.AddVar(update, "update", "Update");
-  file.AddMean(node, "mean_intval", "Average symbiont interaction value");
-  file.AddTotal(node1, "count", "Total number of symbionts");
+  file.AddMean(sym_intval_node, "mean_intval", "Average symbiont interaction value");
+  file.AddTotal(sym_count_node, "count", "Total number of symbionts");
 
   //interaction val histogram
-  file.AddHistBin(node, 0, "Hist_-1", "Count for histogram bin -1 to <-0.9");
-  file.AddHistBin(node, 1, "Hist_-0.9", "Count for histogram bin -0.9 to <-0.8");
-  file.AddHistBin(node, 2, "Hist_-0.8", "Count for histogram bin -0.8 to <-0.7");
-  file.AddHistBin(node, 3, "Hist_-0.7", "Count for histogram bin -0.7 to <-0.6");
-  file.AddHistBin(node, 4, "Hist_-0.6", "Count for histogram bin -0.6 to <-0.5");
-  file.AddHistBin(node, 5, "Hist_-0.5", "Count for histogram bin -0.5 to <-0.4");
-  file.AddHistBin(node, 6, "Hist_-0.4", "Count for histogram bin -0.4 to <-0.3");
-  file.AddHistBin(node, 7, "Hist_-0.3", "Count for histogram bin -0.3 to <-0.2");
-  file.AddHistBin(node, 8, "Hist_-0.2", "Count for histogram bin -0.2 to <-0.1");
-  file.AddHistBin(node, 9, "Hist_-0.1", "Count for histogram bin -0.1 to <0.0");
-  file.AddHistBin(node, 10, "Hist_0.0", "Count for histogram bin 0.0 to <0.1");
-  file.AddHistBin(node, 11, "Hist_0.1", "Count for histogram bin 0.1 to <0.2");
-  file.AddHistBin(node, 12, "Hist_0.2", "Count for histogram bin 0.2 to <0.3");
-  file.AddHistBin(node, 13, "Hist_0.3", "Count for histogram bin 0.3 to <0.4");
-  file.AddHistBin(node, 14, "Hist_0.4", "Count for histogram bin 0.4 to <0.5");
-  file.AddHistBin(node, 15, "Hist_0.5", "Count for histogram bin 0.5 to <0.6");
-  file.AddHistBin(node, 16, "Hist_0.6", "Count for histogram bin 0.6 to <0.7");
-  file.AddHistBin(node, 17, "Hist_0.7", "Count for histogram bin 0.7 to <0.8");
-  file.AddHistBin(node, 18, "Hist_0.8", "Count for histogram bin 0.8 to <0.9");
-  file.AddHistBin(node, 19, "Hist_0.9", "Count for histogram bin 0.9 to 1.0");
+  file.AddHistBin(sym_intval_node, 0, "Hist_-1", "Count for histogram bin -1 to <-0.9");
+  file.AddHistBin(sym_intval_node, 1, "Hist_-0.9", "Count for histogram bin -0.9 to <-0.8");
+  file.AddHistBin(sym_intval_node, 2, "Hist_-0.8", "Count for histogram bin -0.8 to <-0.7");
+  file.AddHistBin(sym_intval_node, 3, "Hist_-0.7", "Count for histogram bin -0.7 to <-0.6");
+  file.AddHistBin(sym_intval_node, 4, "Hist_-0.6", "Count for histogram bin -0.6 to <-0.5");
+  file.AddHistBin(sym_intval_node, 5, "Hist_-0.5", "Count for histogram bin -0.5 to <-0.4");
+  file.AddHistBin(sym_intval_node, 6, "Hist_-0.4", "Count for histogram bin -0.4 to <-0.3");
+  file.AddHistBin(sym_intval_node, 7, "Hist_-0.3", "Count for histogram bin -0.3 to <-0.2");
+  file.AddHistBin(sym_intval_node, 8, "Hist_-0.2", "Count for histogram bin -0.2 to <-0.1");
+  file.AddHistBin(sym_intval_node, 9, "Hist_-0.1", "Count for histogram bin -0.1 to <0.0");
+  file.AddHistBin(sym_intval_node, 10, "Hist_0.0", "Count for histogram bin 0.0 to <0.1");
+  file.AddHistBin(sym_intval_node, 11, "Hist_0.1", "Count for histogram bin 0.1 to <0.2");
+  file.AddHistBin(sym_intval_node, 12, "Hist_0.2", "Count for histogram bin 0.2 to <0.3");
+  file.AddHistBin(sym_intval_node, 13, "Hist_0.3", "Count for histogram bin 0.3 to <0.4");
+  file.AddHistBin(sym_intval_node, 14, "Hist_0.4", "Count for histogram bin 0.4 to <0.5");
+  file.AddHistBin(sym_intval_node, 15, "Hist_0.5", "Count for histogram bin 0.5 to <0.6");
+  file.AddHistBin(sym_intval_node, 16, "Hist_0.6", "Count for histogram bin 0.6 to <0.7");
+  file.AddHistBin(sym_intval_node, 17, "Hist_0.7", "Count for histogram bin 0.7 to <0.8");
+  file.AddHistBin(sym_intval_node, 18, "Hist_0.8", "Count for histogram bin 0.8 to <0.9");
+  file.AddHistBin(sym_intval_node, 19, "Hist_0.9", "Count for histogram bin 0.9 to 1.0");
 
   file.PrintHeaderKeys();
 
@@ -99,34 +99,34 @@ emp::DataFile & SymWorld::SetupHostIntValFile(const std::string & filename) {
  * what columns should be called.
  */
 void SymWorld::SetupHostFileColumns(emp::DataFile & file){
-  auto & node = GetHostIntValDataNode();
-  auto & node1 = GetHostCountDataNode();
+  auto & host_intval_node = GetHostIntValDataNode();
+  auto & host_count_node = GetHostCountDataNode();
   auto & uninf_hosts_node = GetUninfectedHostsDataNode();
 
   file.AddVar(update, "update", "Update");
-  file.AddMean(node, "mean_intval", "Average host interaction value");
-  file.AddTotal(node1, "count", "Total number of hosts");
+  file.AddMean(host_intval_node, "mean_intval", "Average host interaction value");
+  file.AddTotal(host_count_node, "count", "Total number of hosts");
   file.AddTotal(uninf_hosts_node, "uninfected_host_count", "Total number of hosts that are uninfected");
-  file.AddHistBin(node, 0, "Hist_-1", "Count for histogram bin -1 to <-0.9");
-  file.AddHistBin(node, 1, "Hist_-0.9", "Count for histogram bin -0.9 to <-0.8");
-  file.AddHistBin(node, 2, "Hist_-0.8", "Count for histogram bin -0.8 to <-0.7");
-  file.AddHistBin(node, 3, "Hist_-0.7", "Count for histogram bin -0.7 to <-0.6");
-  file.AddHistBin(node, 4, "Hist_-0.6", "Count for histogram bin -0.6 to <-0.5");
-  file.AddHistBin(node, 5, "Hist_-0.5", "Count for histogram bin -0.5 to <-0.4");
-  file.AddHistBin(node, 6, "Hist_-0.4", "Count for histogram bin -0.4 to <-0.3");
-  file.AddHistBin(node, 7, "Hist_-0.3", "Count for histogram bin -0.3 to <-0.2");
-  file.AddHistBin(node, 8, "Hist_-0.2", "Count for histogram bin -0.2 to <-0.1");
-  file.AddHistBin(node, 9, "Hist_-0.1", "Count for histogram bin -0.1 to <0.0");
-  file.AddHistBin(node, 10, "Hist_0.0", "Count for histogram bin 0.0 to <0.1");
-  file.AddHistBin(node, 11, "Hist_0.1", "Count for histogram bin 0.1 to <0.2");
-  file.AddHistBin(node, 12, "Hist_0.2", "Count for histogram bin 0.2 to <0.3");
-  file.AddHistBin(node, 13, "Hist_0.3", "Count for histogram bin 0.3 to <0.4");
-  file.AddHistBin(node, 14, "Hist_0.4", "Count for histogram bin 0.4 to <0.5");
-  file.AddHistBin(node, 15, "Hist_0.5", "Count for histogram bin 0.5 to <0.6");
-  file.AddHistBin(node, 16, "Hist_0.6", "Count for histogram bin 0.6 to <0.7");
-  file.AddHistBin(node, 17, "Hist_0.7", "Count for histogram bin 0.7 to <0.8");
-  file.AddHistBin(node, 18, "Hist_0.8", "Count for histogram bin 0.8 to <0.9");
-  file.AddHistBin(node, 19, "Hist_0.9", "Count for histogram bin 0.9 to 1.0");
+  file.AddHistBin(host_intval_node, 0, "Hist_-1", "Count for histogram bin -1 to <-0.9");
+  file.AddHistBin(host_intval_node, 1, "Hist_-0.9", "Count for histogram bin -0.9 to <-0.8");
+  file.AddHistBin(host_intval_node, 2, "Hist_-0.8", "Count for histogram bin -0.8 to <-0.7");
+  file.AddHistBin(host_intval_node, 3, "Hist_-0.7", "Count for histogram bin -0.7 to <-0.6");
+  file.AddHistBin(host_intval_node, 4, "Hist_-0.6", "Count for histogram bin -0.6 to <-0.5");
+  file.AddHistBin(host_intval_node, 5, "Hist_-0.5", "Count for histogram bin -0.5 to <-0.4");
+  file.AddHistBin(host_intval_node, 6, "Hist_-0.4", "Count for histogram bin -0.4 to <-0.3");
+  file.AddHistBin(host_intval_node, 7, "Hist_-0.3", "Count for histogram bin -0.3 to <-0.2");
+  file.AddHistBin(host_intval_node, 8, "Hist_-0.2", "Count for histogram bin -0.2 to <-0.1");
+  file.AddHistBin(host_intval_node, 9, "Hist_-0.1", "Count for histogram bin -0.1 to <0.0");
+  file.AddHistBin(host_intval_node, 10, "Hist_0.0", "Count for histogram bin 0.0 to <0.1");
+  file.AddHistBin(host_intval_node, 11, "Hist_0.1", "Count for histogram bin 0.1 to <0.2");
+  file.AddHistBin(host_intval_node, 12, "Hist_0.2", "Count for histogram bin 0.2 to <0.3");
+  file.AddHistBin(host_intval_node, 13, "Hist_0.3", "Count for histogram bin 0.3 to <0.4");
+  file.AddHistBin(host_intval_node, 14, "Hist_0.4", "Count for histogram bin 0.4 to <0.5");
+  file.AddHistBin(host_intval_node, 15, "Hist_0.5", "Count for histogram bin 0.5 to <0.6");
+  file.AddHistBin(host_intval_node, 16, "Hist_0.6", "Count for histogram bin 0.6 to <0.7");
+  file.AddHistBin(host_intval_node, 17, "Hist_0.7", "Count for histogram bin 0.7 to <0.8");
+  file.AddHistBin(host_intval_node, 18, "Hist_0.8", "Count for histogram bin 0.8 to <0.9");
+  file.AddHistBin(host_intval_node, 19, "Hist_0.9", "Count for histogram bin 0.9 to 1.0");
 }
 
 
@@ -146,39 +146,39 @@ void SymWorld::SetupHostFileColumns(emp::DataFile & file){
  */
 emp::DataFile & SymWorld::SetUpFreeLivingSymFile(const std::string & filename){
   auto & file = SetupFile(filename);
-  auto & node1 = GetSymCountDataNode(); //count
-  auto & node2 = GetCountFreeSymsDataNode();
-  auto & node3 = GetCountHostedSymsDataNode();
-  auto & node4 = GetSymIntValDataNode(); //interaction_val
-  auto & node5 = GetFreeSymIntValDataNode();
-  auto & node6 = GetHostedSymIntValDataNode();
-  auto & node7 = GetSymInfectChanceDataNode(); //infect chance
-  auto & node8 = GetFreeSymInfectChanceDataNode();
-  auto & node9 = GetHostedSymInfectChanceDataNode();
-  auto & node10 = GetInfectionAttemptCount(); //infection rate
-  auto & node11 = GetInfectionSuccessCount();
+  auto & all_sym_count_node = GetSymCountDataNode(); //count
+  auto & free_sym_count_node = GetCountFreeSymsDataNode();
+  auto & hosteed_sym_count_node = GetCountHostedSymsDataNode();
+  auto & all_sym_intval_node = GetSymIntValDataNode(); //interaction_val
+  auto & free_sym_intval_node = GetFreeSymIntValDataNode();
+  auto & hosted_sym_intval_node = GetHostedSymIntValDataNode();
+  auto & all_sym_infect_chance_node = GetSymInfectChanceDataNode(); //infect chance
+  auto & free_sym_infect_chance_node = GetFreeSymInfectChanceDataNode();
+  auto & hosted_sym_infect_chance_node = GetHostedSymInfectChanceDataNode();
+  auto & infection_attempt_count_node = GetInfectionAttemptCountDataNode(); //infection rate
+  auto & infection_success_count_node = GetInfectionSuccessCountDataNode();
 
   file.AddVar(update, "update", "Update");
 
   //count
-  file.AddTotal(node1, "count", "Total number of symbionts");
-  file.AddTotal(node2, "free_syms", "Total number of free syms");
-  file.AddTotal(node3, "hosted_syms", "Total number of syms in a host");
+  file.AddTotal(all_sym_count_node, "count", "Total number of symbionts");
+  file.AddTotal(free_sym_count_node, "free_syms", "Total number of free syms");
+  file.AddTotal(hosteed_sym_count_node, "hosted_syms", "Total number of syms in a host");
 
 
   //interaction val
-  file.AddMean(node4, "mean_intval", "Average symbiont interaction value");
-  file.AddMean(node5, "mean_freeintval", "Average free symbiont interaction value");
-  file.AddMean(node6, "mean_hostedintval", "Average hosted symbiont interaction value");
+  file.AddMean(all_sym_intval_node, "mean_intval", "Average symbiont interaction value");
+  file.AddMean(free_sym_intval_node, "mean_freeintval", "Average free symbiont interaction value");
+  file.AddMean(hosted_sym_intval_node, "mean_hostedintval", "Average hosted symbiont interaction value");
 
   //infection chance
-  file.AddMean(node7, "mean_infectchance", "Average symbiont infection chance");
-  file.AddMean(node8, "mean_freeinfectchance", "Average free symbiont infection chance");
-  file.AddMean(node9, "mean_hostedinfectchance", "Average hosted symbiont infection chance");
+  file.AddMean(all_sym_infect_chance_node, "mean_infectchance", "Average symbiont infection chance");
+  file.AddMean(free_sym_infect_chance_node, "mean_freeinfectchance", "Average free symbiont infection chance");
+  file.AddMean(hosted_sym_infect_chance_node, "mean_hostedinfectchance", "Average hosted symbiont infection chance");
 
   //infection rate
-  file.AddTotal(node10, "attempted_infections", "Number of attempted infections of a host by a symbiont since last recorded", true);
-  file.AddTotal(node11, "successful_infections", "Number of successful infections of a host by a symbiont since last recorded", true);
+  file.AddTotal(infection_attempt_count_node, "attempted_infections", "Number of attempted infections of a host by a symbiont since last recorded", true);
+  file.AddTotal(infection_success_count_node, "successful_infections", "Number of successful infections of a host by a symbiont since last recorded", true);
 
   file.PrintHeaderKeys();
 
@@ -211,23 +211,23 @@ void SymWorld::WritePhylogenyFile(const std::string & filename) {
 
 emp::DataFile & SymWorld::SetUpTransmissionFile(const std::string & filename){
   auto & file = SetupFile(filename);
-  auto & node1 = GetHorizontalTransmissionAttemptCount();
-  auto & node2 = GetHorizontalTransmissionSuccessCount();
-  auto & node3 = GetVerticalTransmissionAttemptCount();
-  auto & node4 = GetFreeLivingSymReproAttemptCount();
-
+  auto & horiz_trans_attempt_node = GetHorizontalTransmissionAttemptCountDataNode();
+  auto & horiz_trans_success_node = GetHorizontalTransmissionSuccessCountDataNode();
+  auto & vert_trans_attempt_node = GetVerticalTransmissionAttemptCountDataNode();
+  
   file.AddVar(update, "update", "Update");
 
   //horizontal transmission
-  file.AddTotal(node1, "attempts_horiztrans", "Total number of horizontal transmission attempts", true);
-  file.AddTotal(node2, "successes_horiztrans", "Total number of horizontal transmission successes", true);
+  file.AddTotal(horiz_trans_attempt_node, "attempts_horiztrans", "Total number of horizontal transmission attempts", true);
+  file.AddTotal(horiz_trans_success_node, "successes_horiztrans", "Total number of horizontal transmission successes", true);
 
   //vertical transmission
-  file.AddTotal(node3, "attempts_verttrans", "Total number of horizontal transmission attempts", true);
+  file.AddTotal(vert_trans_attempt_node, "attempts_verttrans", "Total number of horizontal transmission attempts", true);
 
   //free living symbiont transmission
   if (my_config->FREE_LIVING_SYMS() == 1) {
-    file.AddTotal(node4, "attempts_freesymrepro", "Total number of attempted free living symbiont births", true);
+    auto& free_sym_birth_attempt_node = GetFreeLivingSymReproAttemptCountDataNode();
+    file.AddTotal(free_sym_birth_attempt_node, "attempts_freesymrepro", "Total number of attempted free living symbiont births", true);
   }
 
   file.PrintHeaderKeys();
@@ -583,7 +583,7 @@ emp::DataMonitor<double,emp::data::Histogram>& SymWorld::GetHostedSymInfectChanc
  * Purpose: To retrieve the data nodes that is tracking the
  * number of attempted horizontal transmissions.
  */
-emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionAttemptCount() {
+emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionAttemptCountDataNode() {
   if (!data_node_attempts_horiztrans) {
     data_node_attempts_horiztrans.New();
   }
@@ -600,7 +600,7 @@ emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionAttemptCount() {
  * Purpose: To retrieve the data nodes that is tracking the
  * number of successful horizontal transmissions.
  */
-emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionSuccessCount() {
+emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionSuccessCountDataNode() {
   if (!data_node_successes_horiztrans) {
     data_node_successes_horiztrans.New();
   }
@@ -617,7 +617,7 @@ emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionSuccessCount() {
  * Purpose: To retrieve the data nodes that is tracking the
  * number of attempted free living symbiont reproductions.
  */
-emp::DataMonitor<int>& SymWorld::GetFreeLivingSymReproAttemptCount() {
+emp::DataMonitor<int>& SymWorld::GetFreeLivingSymReproAttemptCountDataNode() {
   if (!data_node_attempts_flsrepro) {
     data_node_attempts_flsrepro.New();
   }
@@ -634,7 +634,7 @@ emp::DataMonitor<int>& SymWorld::GetFreeLivingSymReproAttemptCount() {
  * Purpose: To retrieve the data nodes that is tracking the
  * number of attempted vertical transmissions.
  */
-emp::DataMonitor<int>& SymWorld::GetVerticalTransmissionAttemptCount() {
+emp::DataMonitor<int>& SymWorld::GetVerticalTransmissionAttemptCountDataNode() {
   if (!data_node_attempts_verttrans) {
     data_node_attempts_verttrans.New();
   }
@@ -650,7 +650,7 @@ emp::DataMonitor<int>& SymWorld::GetVerticalTransmissionAttemptCount() {
  * Purpose: To retrieve the data node that is tracking the
  * number of attempted symbiont infections of a host.
  */
-emp::DataMonitor<int>& SymWorld::GetInfectionAttemptCount() {
+emp::DataMonitor<int>& SymWorld::GetInfectionAttemptCountDataNode() {
   if (!data_node_attempts_infection) {
     data_node_attempts_infection.New();
   }
@@ -666,7 +666,7 @@ emp::DataMonitor<int>& SymWorld::GetInfectionAttemptCount() {
  * Purpose: To retrieve the data node that is tracking the
  * number of successful symbiont infections of a host.
  */
-emp::DataMonitor<int>& SymWorld::GetInfectionSuccessCount() {
+emp::DataMonitor<int>& SymWorld::GetInfectionSuccessCountDataNode() {
   if (!data_node_successes_infection) {
     data_node_successes_infection.New();
   }

--- a/source/default_mode/DataNodes.h
+++ b/source/default_mode/DataNodes.h
@@ -148,7 +148,7 @@ emp::DataFile & SymWorld::SetUpFreeLivingSymFile(const std::string & filename){
   auto & file = SetupFile(filename);
   auto & all_sym_count_node = GetSymCountDataNode(); //count
   auto & free_sym_count_node = GetCountFreeSymsDataNode();
-  auto & hosteed_sym_count_node = GetCountHostedSymsDataNode();
+  auto & hosted_sym_count_node = GetCountHostedSymsDataNode();
   auto & all_sym_intval_node = GetSymIntValDataNode(); //interaction_val
   auto & free_sym_intval_node = GetFreeSymIntValDataNode();
   auto & hosted_sym_intval_node = GetHostedSymIntValDataNode();
@@ -163,7 +163,7 @@ emp::DataFile & SymWorld::SetUpFreeLivingSymFile(const std::string & filename){
   //count
   file.AddTotal(all_sym_count_node, "count", "Total number of symbionts");
   file.AddTotal(free_sym_count_node, "free_syms", "Total number of free syms");
-  file.AddTotal(hosteed_sym_count_node, "hosted_syms", "Total number of syms in a host");
+  file.AddTotal(hosted_sym_count_node, "hosted_syms", "Total number of syms in a host");
 
 
   //interaction val

--- a/source/default_mode/DataNodes.h
+++ b/source/default_mode/DataNodes.h
@@ -214,6 +214,7 @@ emp::DataFile & SymWorld::SetUpTransmissionFile(const std::string & filename){
   auto & node1 = GetHorizontalTransmissionAttemptCount();
   auto & node2 = GetHorizontalTransmissionSuccessCount();
   auto & node3 = GetVerticalTransmissionAttemptCount();
+  auto & node4 = GetFreeLivingSymReproAttemptCount();
 
   file.AddVar(update, "update", "Update");
 
@@ -223,6 +224,11 @@ emp::DataFile & SymWorld::SetUpTransmissionFile(const std::string & filename){
 
   //vertical transmission
   file.AddTotal(node3, "attempts_verttrans", "Total number of horizontal transmission attempts", true);
+
+  //free living symbiont transmission
+  if (my_config->FREE_LIVING_SYMS() == 1) {
+    file.AddTotal(node4, "attempts_freesymrepro", "Total number of attempted free living symbiont births", true);
+  }
 
   file.PrintHeaderKeys();
 
@@ -599,6 +605,23 @@ emp::DataMonitor<int>& SymWorld::GetHorizontalTransmissionSuccessCount() {
     data_node_successes_horiztrans.New();
   }
   return *data_node_successes_horiztrans;
+}
+
+
+/**
+ * Input: None
+ *
+ * Output: The DataMonitor<int>& that has the information representing
+ * how many attempts were made by free living symbionts to reproduce.
+ *
+ * Purpose: To retrieve the data nodes that is tracking the
+ * number of attempted free living symbiont reproductions.
+ */
+emp::DataMonitor<int>& SymWorld::GetFreeLivingSymReproAttemptCount() {
+  if (!data_node_attempts_flsrepro) {
+    data_node_attempts_flsrepro.New();
+  }
+  return *data_node_attempts_flsrepro;
 }
 
 

--- a/source/default_mode/SymWorld.h
+++ b/source/default_mode/SymWorld.h
@@ -464,12 +464,12 @@ public:
   emp::DataMonitor<int>& GetCountHostedSymsDataNode();
   emp::DataMonitor<int>& GetCountFreeSymsDataNode();
   emp::DataMonitor<int>& GetUninfectedHostsDataNode();
-  emp::DataMonitor<int>& GetHorizontalTransmissionAttemptCount();
-  emp::DataMonitor<int>& GetHorizontalTransmissionSuccessCount();
-  emp::DataMonitor<int>& GetVerticalTransmissionAttemptCount();
-  emp::DataMonitor<int>& GetFreeLivingSymReproAttemptCount();
-  emp::DataMonitor<int>& GetInfectionAttemptCount();
-  emp::DataMonitor<int>& GetInfectionSuccessCount();
+  emp::DataMonitor<int>& GetHorizontalTransmissionAttemptCountDataNode();
+  emp::DataMonitor<int>& GetHorizontalTransmissionSuccessCountDataNode();
+  emp::DataMonitor<int>& GetVerticalTransmissionAttemptCountDataNode();
+  emp::DataMonitor<int>& GetFreeLivingSymReproAttemptCountDataNode();
+  emp::DataMonitor<int>& GetInfectionAttemptCountDataNode();
+  emp::DataMonitor<int>& GetInfectionSuccessCountDataNode();
   emp::DataMonitor<double,emp::data::Histogram>& GetHostIntValDataNode();
   emp::DataMonitor<double,emp::data::Histogram>& GetSymIntValDataNode();
   emp::DataMonitor<double,emp::data::Histogram>& GetFreeSymIntValDataNode();
@@ -573,12 +573,12 @@ public:
     size_t i = pos.GetPopID();
     //the sym can either move into a parallel sym or to some random position
     if(IsOccupied(i) && sym_pop[i]->WantsToInfect()) {
-      GetInfectionAttemptCount().AddDatum(1);
+      GetInfectionAttemptCountDataNode().AddDatum(1);
       emp::Ptr<Organism> sym = ExtractSym(i);
       if(sym->InfectionFails()) sym.Delete(); //if the sym tries to infect and fails it dies
       else {
         bool infected = pop[i]->AddSymbiont(sym);
-        if(infected) GetInfectionSuccessCount().AddDatum(1);
+        if(infected) GetInfectionSuccessCountDataNode().AddDatum(1);
       }
     }
     else if(my_config->MOVE_FREE_SYMS()) {

--- a/source/default_mode/SymWorld.h
+++ b/source/default_mode/SymWorld.h
@@ -72,6 +72,7 @@ protected:
   emp::Ptr<emp::DataMonitor<int>> data_node_uninf_hosts;
   emp::Ptr<emp::DataMonitor<int>> data_node_attempts_horiztrans;
   emp::Ptr<emp::DataMonitor<int>> data_node_successes_horiztrans;
+  emp::Ptr<emp::DataMonitor<int>> data_node_attempts_flsrepro;
   emp::Ptr<emp::DataMonitor<int>> data_node_attempts_verttrans;
   emp::Ptr<emp::DataMonitor<int>> data_node_attempts_infection;
   emp::Ptr<emp::DataMonitor<int>> data_node_successes_infection;
@@ -127,6 +128,7 @@ public:
     if (data_node_uninf_hosts) data_node_uninf_hosts.Delete();
     if (data_node_attempts_horiztrans) data_node_attempts_horiztrans.Delete();
     if (data_node_successes_horiztrans) data_node_successes_horiztrans.Delete();
+    if (data_node_attempts_flsrepro) data_node_attempts_flsrepro.Delete();
     if (data_node_attempts_verttrans) data_node_attempts_verttrans.Delete();
     if (data_node_attempts_infection) data_node_attempts_infection.Delete();
     if (data_node_successes_infection) data_node_successes_infection.Delete();
@@ -465,6 +467,7 @@ public:
   emp::DataMonitor<int>& GetHorizontalTransmissionAttemptCount();
   emp::DataMonitor<int>& GetHorizontalTransmissionSuccessCount();
   emp::DataMonitor<int>& GetVerticalTransmissionAttemptCount();
+  emp::DataMonitor<int>& GetFreeLivingSymReproAttemptCount();
   emp::DataMonitor<int>& GetInfectionAttemptCount();
   emp::DataMonitor<int>& GetInfectionSuccessCount();
   emp::DataMonitor<double,emp::data::Histogram>& GetHostIntValDataNode();

--- a/source/default_mode/Symbiont.h
+++ b/source/default_mode/Symbiont.h
@@ -581,7 +581,7 @@ public:
   void HorizontalTransmission(emp::WorldPosition location) {
     if (my_config->HORIZ_TRANS()) { //non-lytic horizontal transmission enabled
       double required_points = my_config->SYM_HORIZ_TRANS_RES();
-      if (my_config->FREE_LIVING_SYMS() && my_host == nullptr && my_config->FREE_SYM_REPRO_RES() > -1) {
+      if (my_config->FREE_LIVING_SYMS() && my_host.IsNull() && my_config->FREE_SYM_REPRO_RES() > -1) {
         required_points = my_config->FREE_SYM_REPRO_RES();
       }
       if (GetPoints() >= required_points) {
@@ -592,13 +592,19 @@ public:
         emp::Ptr<Organism> sym_baby = Reproduce();
         emp::WorldPosition new_pos = my_world->SymDoBirth(sym_baby, location);
 
-        //horizontal transmission data nodes
-        emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCount();
-        data_node_attempts_horiztrans.AddDatum(1);
+        if (my_config->FREE_LIVING_SYMS() && my_host.IsNull()) {
+          //free living symbiont birth data nodes
+          emp::DataMonitor<int>& data_node_attempts_flsrepro = my_world->GetFreeLivingSymReproAttemptCount();
+          data_node_attempts_flsrepro.AddDatum(1);
+        } else {
+          //horizontal transmission data nodes
+          emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCount();
+          data_node_attempts_horiztrans.AddDatum(1);
 
-        emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCount();
-        if(new_pos.IsValid()){
-          data_node_successes_horiztrans.AddDatum(1);
+          emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCount();
+          if (new_pos.IsValid()) {
+            data_node_successes_horiztrans.AddDatum(1);
+          }
         }
       }
     }

--- a/source/default_mode/Symbiont.h
+++ b/source/default_mode/Symbiont.h
@@ -566,7 +566,7 @@ public:
       host_baby->AddSymbiont(sym_baby);
 
       //vertical transmission data node
-      emp::DataMonitor<int>& data_node_attempts_verttrans = my_world->GetVerticalTransmissionAttemptCount();
+      emp::DataMonitor<int>& data_node_attempts_verttrans = my_world->GetVerticalTransmissionAttemptCountDataNode();
       data_node_attempts_verttrans.AddDatum(1);
     }
   }
@@ -594,14 +594,14 @@ public:
 
         if (my_config->FREE_LIVING_SYMS() && my_host.IsNull()) {
           //free living symbiont birth data nodes
-          emp::DataMonitor<int>& data_node_attempts_flsrepro = my_world->GetFreeLivingSymReproAttemptCount();
+          emp::DataMonitor<int>& data_node_attempts_flsrepro = my_world->GetFreeLivingSymReproAttemptCountDataNode();
           data_node_attempts_flsrepro.AddDatum(1);
         } else {
           //horizontal transmission data nodes
-          emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCount();
+          emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCountDataNode();
           data_node_attempts_horiztrans.AddDatum(1);
 
-          emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCount();
+          emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCountDataNode();
           if (new_pos.IsValid()) {
             data_node_successes_horiztrans.AddDatum(1);
           }

--- a/source/efficient_mode/EfficientSymbiont.h
+++ b/source/efficient_mode/EfficientSymbiont.h
@@ -245,7 +245,7 @@ public:
       host_baby->AddSymbiont(sym_baby);
 
       //vertical transmission data node
-      emp::DataMonitor<int>& data_node_attempts_verttrans = my_world->GetVerticalTransmissionAttemptCount();
+      emp::DataMonitor<int>& data_node_attempts_verttrans = my_world->GetVerticalTransmissionAttemptCountDataNode();
       data_node_attempts_verttrans.AddDatum(1);
     }
   }
@@ -267,10 +267,10 @@ public:
         emp::WorldPosition new_pos = my_world->SymDoBirth(sym_baby, location);
 
         //horizontal transmission data nodes
-        emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCount();
+        emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCountDataNode();
         data_node_attempts_horiztrans.AddDatum(1);
 
-        emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCount();
+        emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCountDataNode();
         if(new_pos.IsValid()){
           data_node_successes_horiztrans.AddDatum(1);
         }

--- a/source/lysis_mode/Phage.h
+++ b/source/lysis_mode/Phage.h
@@ -300,8 +300,8 @@ public:
     data_node_burst_size.AddDatum(repro_syms.size());
     emp::DataMonitor<int>& data_node_burst_count = my_world->GetBurstCountDataNode();
     data_node_burst_count.AddDatum(1);
-    emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCount();
-    emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCount();
+    emp::DataMonitor<int>& data_node_attempts_horiztrans = my_world->GetHorizontalTransmissionAttemptCountDataNode();
+    emp::DataMonitor<int>& data_node_successes_horiztrans = my_world->GetHorizontalTransmissionSuccessCountDataNode();
 
     for(size_t r=0; r<repro_syms.size(); r++) {
       emp::WorldPosition new_pos = my_world->SymDoBirth(repro_syms[r], location);
@@ -354,7 +354,7 @@ public:
       host_baby->AddSymbiont(phage_baby);
 
       //vertical transmission data node
-      emp::DataMonitor<int>& data_node_attempts_verttrans = my_world->GetVerticalTransmissionAttemptCount();
+      emp::DataMonitor<int>& data_node_attempts_verttrans = my_world->GetVerticalTransmissionAttemptCountDataNode();
       data_node_attempts_verttrans.AddDatum(1);
     }
   }

--- a/source/test/default_mode_test/DataNodes.test.cc
+++ b/source/test/default_mode_test/DataNodes.test.cc
@@ -606,16 +606,16 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
         symbiont->HorizontalTransmission(parent_pos);
         REQUIRE(world.GetNumOrgs() == 2);
 
-        THEN("The count of attempted horizontal transmissions increments"){
-          REQUIRE(data_node_attempts_horiztrans.GetTotal() == 1);
+        THEN("The count of attempted horizontal transmissions does not increment"){
+          REQUIRE(data_node_attempts_horiztrans.GetTotal() == 0);
         }
       }
         WHEN("There are no valid cells to transmit into and the symbiont dies trying to transmit"){
         world.Resize(0);
         symbiont->HorizontalTransmission(parent_pos);
         REQUIRE(world.GetNumOrgs() == 1);
-        THEN("The count of attempted horizontal transmissions increments"){
-          REQUIRE(data_node_attempts_horiztrans.GetTotal() == 1);
+        THEN("The count of attempted horizontal transmissions does not increment"){
+          REQUIRE(data_node_attempts_horiztrans.GetTotal() == 0);
         }
         symbiont.Delete(); // won't be caught by symworld destructor due to resize
       }
@@ -670,8 +670,8 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
         symbiont->HorizontalTransmission(parent_pos);
         REQUIRE(world.GetNumOrgs() == 2);
 
-        THEN("The count of successful horizontal transmissions increments"){
-          REQUIRE(data_node_successes_horiztrans.GetTotal() == 1);
+        THEN("The count of successful horizontal transmissions does not increment"){
+          REQUIRE(data_node_successes_horiztrans.GetTotal() == 0);
         }
       }
       WHEN("There are no valid cells to transmit into and the symbiont dies trying to transmit"){
@@ -703,6 +703,70 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
         REQUIRE(host->HasSym() == false);
         THEN("The count of successful horizontal transmissions does not change"){
           REQUIRE(data_node_successes_horiztrans.GetTotal() == 0);
+        }
+      }
+      symbiont.Delete();
+    }
+
+  }
+}
+
+TEST_CASE("GetFreeLivingSymReproAttemptCount", "[default]") {
+  GIVEN("a world") {
+    emp::Random random(17);
+    SymConfigBase config;
+    int int_val = 0;
+    SymWorld world(random, &config);
+    size_t world_size = 4;
+    world.Resize(world_size);
+    config.SYM_HORIZ_TRANS_RES(0);
+
+    emp::DataMonitor<int>& data_node_attempts_flsrepro = world.GetFreeLivingSymReproAttemptCount();
+    emp::WorldPosition parent_pos = emp::WorldPosition(0, 0);
+    REQUIRE(data_node_attempts_flsrepro.GetTotal() == 0);
+
+    WHEN("Free living symbionts are allowed") {
+      config.FREE_LIVING_SYMS(1);
+      emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(&random, &world, &config, int_val);
+      world.AddOrgAt(symbiont, parent_pos);
+
+      WHEN("A symbiont successfully transmits into a free living cell") {
+        symbiont->HorizontalTransmission(parent_pos);
+        REQUIRE(world.GetNumOrgs() == 2);
+
+        THEN("The count of attempted free living symbiont births increments") {
+          REQUIRE(data_node_attempts_flsrepro.GetTotal() == 1);
+        }
+      }
+      WHEN("There are no valid cells to transmit into and the symbiont dies trying to transmit") {
+        world.Resize(0);
+        symbiont->HorizontalTransmission(parent_pos);
+        REQUIRE(world.GetNumOrgs() == 1);
+        THEN("The count of attempted free living symbiont births increments") {
+          REQUIRE(data_node_attempts_flsrepro.GetTotal() == 1);
+        }
+        symbiont.Delete(); // won't be caught by symworld destructor due to resize
+      }
+    }
+    WHEN("Free living symbionts are not allowed") {
+      config.FREE_LIVING_SYMS(0);
+      emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(&random, &world, &config, int_val);
+      emp::Ptr<Host> host = emp::NewPtr<Host>(&random, &world, &config, int_val);
+      world.AddOrgAt(host, 1);
+
+      WHEN("A symbiont successfully horizontally transmits into a host") {
+        symbiont->HorizontalTransmission(parent_pos);
+        REQUIRE(host->HasSym() == true);
+        THEN("The count of attempted free living symbiont births does not increment") {
+          REQUIRE(data_node_attempts_flsrepro.GetTotal() == 0);
+        }
+      }
+      WHEN("A symbiont dies trying to horizontally transmit into a host") {
+        config.SYM_LIMIT(0);
+        symbiont->HorizontalTransmission(parent_pos);
+        REQUIRE(host->HasSym() == false);
+        THEN("The count of attempted free living symbiont births does not increment") {
+          REQUIRE(data_node_attempts_flsrepro.GetTotal() == 0);
         }
       }
       symbiont.Delete();

--- a/source/test/default_mode_test/DataNodes.test.cc
+++ b/source/test/default_mode_test/DataNodes.test.cc
@@ -583,7 +583,7 @@ TEST_CASE("GetHostedSymInfectChanceDataNode", "[default]"){
   }
 }
 
-TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
+TEST_CASE("GetHorizontalTransmissionAttemptCountDataNode", "[default]"){
   GIVEN( "a world" ) {
     emp::Random random(17);
     SymConfigBase config;
@@ -593,7 +593,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
     world.Resize(world_size);
     config.SYM_HORIZ_TRANS_RES(0);
 
-    emp::DataMonitor<int>& data_node_attempts_horiztrans = world.GetHorizontalTransmissionAttemptCount();
+    emp::DataMonitor<int>& data_node_attempts_horiztrans = world.GetHorizontalTransmissionAttemptCountDataNode();
     emp::WorldPosition parent_pos = emp::WorldPosition(0, 0);
     REQUIRE(data_node_attempts_horiztrans.GetTotal() == 0);
 
@@ -647,7 +647,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
   }
 }
 
-TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
+TEST_CASE("GetHorizontalTransmissionSuccessCountDataNode", "[default]"){
   GIVEN( "a world" ) {
     emp::Random random(17);
     SymConfigBase config;
@@ -657,7 +657,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
     world.Resize(world_size);
     config.SYM_HORIZ_TRANS_RES(0);
 
-    emp::DataMonitor<int>& data_node_successes_horiztrans = world.GetHorizontalTransmissionSuccessCount();
+    emp::DataMonitor<int>& data_node_successes_horiztrans = world.GetHorizontalTransmissionSuccessCountDataNode();
     emp::WorldPosition parent_pos = emp::WorldPosition(0, 0);
     REQUIRE(data_node_successes_horiztrans.GetTotal() == 0);
 
@@ -711,7 +711,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
   }
 }
 
-TEST_CASE("GetFreeLivingSymReproAttemptCount", "[default]") {
+TEST_CASE("GetFreeLivingSymReproAttemptCountDataNode", "[default]") {
   GIVEN("a world") {
     emp::Random random(17);
     SymConfigBase config;
@@ -721,7 +721,7 @@ TEST_CASE("GetFreeLivingSymReproAttemptCount", "[default]") {
     world.Resize(world_size);
     config.SYM_HORIZ_TRANS_RES(0);
 
-    emp::DataMonitor<int>& data_node_attempts_flsrepro = world.GetFreeLivingSymReproAttemptCount();
+    emp::DataMonitor<int>& data_node_attempts_flsrepro = world.GetFreeLivingSymReproAttemptCountDataNode();
     emp::WorldPosition parent_pos = emp::WorldPosition(0, 0);
     REQUIRE(data_node_attempts_flsrepro.GetTotal() == 0);
 
@@ -775,7 +775,7 @@ TEST_CASE("GetFreeLivingSymReproAttemptCount", "[default]") {
   }
 }
 
-TEST_CASE("GetVerticalTransmissionAttemptCount", "[default]"){
+TEST_CASE("GetVerticalTransmissionAttemptCountDataNode", "[default]"){
   GIVEN( "a world" ) {
     emp::Random random(17);
     SymConfigBase config;
@@ -786,7 +786,7 @@ TEST_CASE("GetVerticalTransmissionAttemptCount", "[default]"){
     config.SYM_VERT_TRANS_RES(0);
     config.VERTICAL_TRANSMISSION(1);
 
-    emp::DataMonitor<int>& data_node_attempts_verttrans = world.GetVerticalTransmissionAttemptCount();
+    emp::DataMonitor<int>& data_node_attempts_verttrans = world.GetVerticalTransmissionAttemptCountDataNode();
     REQUIRE(data_node_attempts_verttrans.GetTotal() == 0);
 
     WHEN("A symbiont baby gets vertically transmitted into a host baby"){
@@ -806,7 +806,7 @@ TEST_CASE("GetVerticalTransmissionAttemptCount", "[default]"){
   }
 }
 
-TEST_CASE("GetInfectionAttemptCount", "[default]") {
+TEST_CASE("GetInfectionAttemptCountDataNode", "[default]") {
   GIVEN("a world") {
     emp::Random random(17);
     SymConfigBase config;
@@ -818,7 +818,7 @@ TEST_CASE("GetInfectionAttemptCount", "[default]") {
     config.SYM_LIMIT(0);
     config.FREE_LIVING_SYMS(1);
     
-    emp::DataMonitor<int>& data_node_attempts_infection = world.GetInfectionAttemptCount();
+    emp::DataMonitor<int>& data_node_attempts_infection = world.GetInfectionAttemptCountDataNode();
     REQUIRE(data_node_attempts_infection.GetTotal() == 0);
 
     size_t host_pos = 1;
@@ -845,7 +845,7 @@ TEST_CASE("GetInfectionAttemptCount", "[default]") {
   }
 }
 
-TEST_CASE("GetInfectionSuccessCount", "[default]") {
+TEST_CASE("GetInfectionSuccessCountDataNode", "[default]") {
   GIVEN("a world") {
     emp::Random random(17);
     SymConfigBase config;
@@ -856,7 +856,7 @@ TEST_CASE("GetInfectionSuccessCount", "[default]") {
     
     config.FREE_LIVING_SYMS(1);
 
-    emp::DataMonitor<int>& data_node_successes_infection = world.GetInfectionSuccessCount();
+    emp::DataMonitor<int>& data_node_successes_infection = world.GetInfectionSuccessCountDataNode();
     REQUIRE(data_node_successes_infection.GetTotal() == 0);
 
     size_t host_pos = 1;


### PR DESCRIPTION
Adding some data nodes to default mode, which track the number of attempted/successful:
- infections of hosts by symbionts
- free living symbionts births, which used to be tracked by the data node tracking hosted symbiont horizontal transmission