### PR TITLE
Health & Stress host bug fix + test

### DIFF
--- a/source/catch/main.cc
+++ b/source/catch/main.cc
@@ -33,6 +33,7 @@
 #include "../test/sgp_mode_test/GenomeLibrary.test.cc"
 #include "../test/sgp_mode_test/SGPWorld.test.cc"
 #include "../test/sgp_mode_test/StressHost.test.cc"
+#include "../test/sgp_mode_test/HealthHost.test.cc"
 
 #include "../test/integration_test/spatial_structure/vt.test.cc"
 #include "../test/integration_test/lysogeny/plr.test.cc"

--- a/source/sgp_mode/HealthHost.h
+++ b/source/sgp_mode/HealthHost.h
@@ -27,7 +27,7 @@ class HealthHost : public SGPHost {
           double _intval = 0.0, emp::vector<emp::Ptr<Organism>> _syms = {},
           emp::vector<emp::Ptr<Organism>> _repro_syms = {},
           double _points = 0.0)
-      : SGPHost(_random, _world, _config, _intval, _syms, _repro_syms, _points) {}
+      : SGPHost(_random, _world, _config, genome, _intval, _syms, _repro_syms, _points) {}
 
   HealthHost(const SGPHost &host)
       : SGPHost(host) {}

--- a/source/sgp_mode/StressHost.h
+++ b/source/sgp_mode/StressHost.h
@@ -28,9 +28,9 @@ public:
     double _intval = 0.0, emp::vector<emp::Ptr<Organism>> _syms = {},
     emp::vector<emp::Ptr<Organism>> _repro_syms = {},
     double _points = 0.0)
-    : SGPHost(_random, _world, _config, _intval, _syms, _repro_syms, _points) {}
+    : SGPHost(_random, _world, _config, genome, _intval, _syms, _repro_syms, _points) {}
 
-  StressHost(const SGPHost& host)
+  StressHost(const StressHost& host)
     : SGPHost(host) {}
 
   /**
@@ -41,7 +41,7 @@ public:
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
   emp::Ptr<Organism> MakeNew() override {
-    emp::Ptr<SGPHost> host_baby = emp::NewPtr<StressHost>(
+    emp::Ptr<StressHost> host_baby = emp::NewPtr<StressHost>(
       random, GetWorld(), sgp_config, GetCPU().GetProgram(), GetIntVal());
     // This organism is reproducing, so it must have gotten off the queue
     GetCPU().state.in_progress_repro = -1;

--- a/source/test/sgp_mode_test/HealthHost.test.cc
+++ b/source/test/sgp_mode_test/HealthHost.test.cc
@@ -1,0 +1,49 @@
+#include "../../sgp_mode/HealthHost.h"
+
+TEST_CASE("Health hosts evolve", "[sgp]") {
+  emp::Random random(32);
+  SymConfigSGP config;
+  config.ORGANISM_TYPE(HEALTH);
+  config.START_MOI(0);
+  config.GRID_X(10);
+  config.GRID_Y(100);
+  config.HOST_REPRO_RES(20);
+  size_t world_size = config.GRID_X() * config.GRID_Y();
+
+  SGPWorld world(random, &config, LogicTasks);
+  world.SetupHosts(&world_size);
+
+  REQUIRE(world.GetNumOrgs() == world_size);
+
+  size_t no_mut_NOT_rate = 600000;
+
+  size_t run_updates = 15000;
+
+  WHEN("Mutation size is 0") {
+    config.MUTATION_SIZE(0); //  chance
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Health hosts do not accrue mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host == 0);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host == no_mut_NOT_rate);
+    }
+  }
+
+  WHEN("Mutation size is greater than 0") {
+    config.MUTATION_SIZE(0.0002);
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Health hosts accrue more mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host > 30);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 4);
+    }
+  }
+}

--- a/source/test/sgp_mode_test/HealthHost.test.cc
+++ b/source/test/sgp_mode_test/HealthHost.test.cc
@@ -43,7 +43,7 @@ TEST_CASE("Health hosts evolve", "[sgp]") {
       auto it = world.GetTaskSet().begin();
       ++it;
       REQUIRE((*it).n_succeeds_host > 30);
-      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 4);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 2);
     }
   }
 }

--- a/source/test/sgp_mode_test/StressHost.test.cc
+++ b/source/test/sgp_mode_test/StressHost.test.cc
@@ -60,3 +60,53 @@ TEST_CASE("Extinction event", "[sgp]") {
     }
   }
 }
+
+
+TEST_CASE("Stress hosts evolve", "[sgp]") {
+  emp::Random random(32);
+  SymConfigSGP config;
+  config.ORGANISM_TYPE(STRESS);
+  config.START_MOI(0);
+  config.EXTINCTION_FREQUENCY(100000);
+  config.GRID_X(10);
+  config.GRID_Y(100);
+  config.HOST_REPRO_RES(20);
+  size_t world_size = config.GRID_X() * config.GRID_Y();
+
+  SGPWorld world(random, &config, LogicTasks);
+  world.SetupHosts(&world_size);
+
+  REQUIRE(world.GetNumOrgs() == world_size);
+
+  size_t no_mut_NOT_rate = 600000;
+
+  size_t run_updates = 15000; 
+
+  WHEN("Mutation size is 0") {
+    config.MUTATION_SIZE(0); //  chance
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Stress hosts do not accrue mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host == 0);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host == no_mut_NOT_rate);
+    }
+  }
+
+  WHEN("Mutation size is greater than 0") {
+    config.MUTATION_SIZE(0.0002); 
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Stress hosts accrue more mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host > 30);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 5);
+    }
+  }
+}

--- a/source/test/sgp_mode_test/StressHost.test.cc
+++ b/source/test/sgp_mode_test/StressHost.test.cc
@@ -106,7 +106,7 @@ TEST_CASE("Stress hosts evolve", "[sgp]") {
       auto it = world.GetTaskSet().begin();
       ++it;
       REQUIRE((*it).n_succeeds_host > 30);
-      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 5);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 2);
     }
   }
 }


### PR DESCRIPTION
SGPHost subclass constructors now send passed genomes on to the SGPHost constructor, permitting inheritance of genomes (and thus evolution). Tests check that an expected amount of NOT evolution can occur for both subclasses.  