### PR TITLE
Stress + Health fix + data files

### DIFF
--- a/source/catch/main.cc
+++ b/source/catch/main.cc
@@ -33,6 +33,7 @@
 #include "../test/sgp_mode_test/GenomeLibrary.test.cc"
 #include "../test/sgp_mode_test/SGPWorld.test.cc"
 #include "../test/sgp_mode_test/SGPHost.test.cc"
+#include "../test/sgp_mode_test/SGPSymbiont.test.cc"
 #include "../test/sgp_mode_test/StressHost.test.cc"
 
 #include "../test/integration_test/spatial_structure/vt.test.cc"

--- a/source/catch/main.cc
+++ b/source/catch/main.cc
@@ -32,6 +32,7 @@
 #include "../test/sgp_mode_test/CPU.test.cc"
 #include "../test/sgp_mode_test/GenomeLibrary.test.cc"
 #include "../test/sgp_mode_test/SGPWorld.test.cc"
+#include "../test/sgp_mode_test/SGPHost.test.cc"
 #include "../test/sgp_mode_test/StressHost.test.cc"
 
 #include "../test/integration_test/spatial_structure/vt.test.cc"

--- a/source/native/symbulation_parasite.cc
+++ b/source/native/symbulation_parasite.cc
@@ -56,6 +56,9 @@ int symbulation_main(int argc, char *argv[]) {
   std::string file_ending = "_SEED" + std::to_string(config.SEED()) + ".data";
 
   world.RunExperiment();
+ 
+  world.WriteTaskCombinationsFile(config.FILE_PATH() + "EndingTaskCombinations" + config.FILE_NAME() +
+    file_ending);
 
   emp::vector<std::pair<emp::Ptr<Organism>, size_t>> dominant_organisms =
       world.GetDominantInfo();

--- a/source/native/symbulation_parasite.cc
+++ b/source/native/symbulation_parasite.cc
@@ -14,6 +14,7 @@
 #include "../default_mode/WorldSetup.cc"
 #include "../sgp_mode/SGPWorldSetup.cc"
 #include "../sgp_mode/Tasks.cc"
+#include "../sgp_mode/SGPHost.cc"
 
 #include <fstream>
 #include <iostream>

--- a/source/native/symbulation_parasite.cc
+++ b/source/native/symbulation_parasite.cc
@@ -57,6 +57,8 @@ int symbulation_main(int argc, char *argv[]) {
 
   world.RunExperiment();
  
+  world.WriteOrgReproHistFile(config.FILE_PATH() + "OrgReproHist" + config.FILE_NAME() +
+    file_ending);
   world.WriteTaskCombinationsFile(config.FILE_PATH() + "EndingTaskCombinations" + config.FILE_NAME() +
     file_ending);
 

--- a/source/sgp_mode/CPU.h
+++ b/source/sgp_mode/CPU.h
@@ -84,6 +84,18 @@ public:
    *
    * Output: None
    *
+   * Purpose: To destruct the objects belonging to CPU.
+   */
+  ~CPU() {
+    state.parent_tasks_performed.Delete();
+    state.tasks_performed.Delete();
+  }
+
+  /**
+   * Input: None
+   *
+   * Output: None
+   *
    * Purpose: Resets the CPU to its initial state.
    */
   void Reset() {

--- a/source/sgp_mode/CPUState.h
+++ b/source/sgp_mode/CPUState.h
@@ -49,6 +49,7 @@ struct CPUState {
 
   emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> used_resources = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>();
   emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> tasks_performed = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>();
+  emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks_performed = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>(true);
   emp::vector<size_t> available_dependencies;
   emp::Ptr<emp::vector<size_t>> shared_available_dependencies =
       emp::NewPtr<emp::vector<size_t>>();

--- a/source/sgp_mode/CPUState.h
+++ b/source/sgp_mode/CPUState.h
@@ -52,6 +52,10 @@ struct CPUState {
   emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks_performed = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>(true);
   int task_change_lose[CPU_BITSET_LENGTH] = { 0 };
   int task_change_gain[CPU_BITSET_LENGTH] = { 0 };
+
+  int task_toward_partner[CPU_BITSET_LENGTH] = { 0 };
+  int task_from_partner[CPU_BITSET_LENGTH] = { 0 };
+
   emp::vector<size_t> available_dependencies;
   emp::Ptr<emp::vector<size_t>> shared_available_dependencies =
       emp::NewPtr<emp::vector<size_t>>();

--- a/source/sgp_mode/CPUState.h
+++ b/source/sgp_mode/CPUState.h
@@ -9,7 +9,7 @@
 #include "emp/bits/BitSet.hpp"
 #include <cstdint>
 
-const int CPU_BITSET_LENGTH = 64;
+const int CPU_BITSET_LENGTH = 16;
 
 /// A helper class for a ring buffer that keeps the latest `len` inputs and
 /// discards the rest.

--- a/source/sgp_mode/CPUState.h
+++ b/source/sgp_mode/CPUState.h
@@ -9,7 +9,7 @@
 #include "emp/bits/BitSet.hpp"
 #include <cstdint>
 
-const int CPU_BITSET_LENGTH = 16;
+const int CPU_BITSET_LENGTH = 9;
 
 /// A helper class for a ring buffer that keeps the latest `len` inputs and
 /// discards the rest.
@@ -50,6 +50,8 @@ struct CPUState {
   emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> used_resources = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>();
   emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> tasks_performed = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>();
   emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks_performed = emp::NewPtr<emp::BitSet<CPU_BITSET_LENGTH>>(true);
+  int task_change_lose[CPU_BITSET_LENGTH] = { 0 };
+  int task_change_gain[CPU_BITSET_LENGTH] = { 0 };
   emp::vector<size_t> available_dependencies;
   emp::Ptr<emp::vector<size_t>> shared_available_dependencies =
       emp::NewPtr<emp::vector<size_t>>();

--- a/source/sgp_mode/HealthHost.h
+++ b/source/sgp_mode/HealthHost.h
@@ -41,8 +41,6 @@ class HealthHost : public SGPHost {
     emp::Ptr<Organism> MakeNew() override {
     emp::Ptr<SGPHost> host_baby = emp::NewPtr<HealthHost>(
         random, GetWorld(), sgp_config, GetCPU().GetProgram(), GetIntVal());
-    // This organism is reproducing, so it must have gotten off the queue
-    GetCPU().state.in_progress_repro = -1;
     return host_baby;
   }
 

--- a/source/sgp_mode/HealthHost.h
+++ b/source/sgp_mode/HealthHost.h
@@ -27,7 +27,7 @@ class HealthHost : public SGPHost {
           double _intval = 0.0, emp::vector<emp::Ptr<Organism>> _syms = {},
           emp::vector<emp::Ptr<Organism>> _repro_syms = {},
           double _points = 0.0)
-      : SGPHost(_random, _world, _config, _intval, _syms, _repro_syms, _points) {}
+      : SGPHost(_random, _world, _config, genome, _intval, _syms, _repro_syms, _points) {}
 
   HealthHost(const SGPHost &host)
       : SGPHost(host) {}

--- a/source/sgp_mode/SGPConfigSetup.h
+++ b/source/sgp_mode/SGPConfigSetup.h
@@ -18,6 +18,7 @@ EMP_EXTEND_CONFIG(SymConfigSGP, SymConfigBase,
 
   VALUE(ORGANISM_TYPE, size_t, 0, "What sgp organisms should population the world? (0 for default SGP, 1 for Health organisms, 2 for stress organisms)"),
   VALUE(VT_TASK_MATCH, bool, 0, "Should task matching be required for vertical transmission? (0 for no, 1 for yes)"),
+  VALUE(TRACK_PARENT_TASKS, bool, 0, "Should parental task completion data be used for reproductive task matching (instead of the individual's task completion data?) (0 for no, 1 for yes"),
 
   GROUP(STRESS, "Stress Settings"),
   VALUE(STRESS_TYPE, size_t, 0, "What kind of stress symbionts should be incorporated in stressful environments? (0 for mutualists, 1 for parasites, 2 for neutrals"),

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -118,34 +118,67 @@ void SGPWorld::WriteTaskCombinationsFile(const std::string& filename) {
 
   // loop through the whole population and keep track of the count of parents
   // who satisfy each tag combination
-  std::unordered_map<std::string, std::pair<int, int>> parent_task_counts;
+  std::unordered_map<std::string, int[4]> matching_task_counts;
   for (size_t i = 0; i < pop.size(); i++) {
     if (!IsOccupied(i)) continue;
     emp::Ptr<SGPHost> host = pop[i].DynamicCast<SGPHost>();
-    std::string host_parent_tasks = host->GetCPU().state.parent_tasks_performed->ToBinaryString();
-    if (emp::Has(parent_task_counts, host_parent_tasks)) {
-      parent_task_counts[host_parent_tasks].first++;
+    std::string host_matching_tasks = (sgp_config->TRACK_PARENT_TASKS()) ? 
+                                    host->GetCPU().state.parent_tasks_performed->ToBinaryString() : 
+                                    host->GetCPU().state.tasks_performed->ToBinaryString();
+    if (emp::Has(matching_task_counts, host_matching_tasks)) {
+      matching_task_counts[host_matching_tasks][0]++;
     }
     else {
-      parent_task_counts[host_parent_tasks] = std::pair<int, int>(1, 0);
+      matching_task_counts[host_matching_tasks][0] = 1;// { 1, 0, 0, 0 };
+
     }
     emp::vector<emp::Ptr<Organism>> syms = host->GetSymbionts();
     for (size_t j = 0; j < syms.size(); j++) {
-      std::string sym_parent_tasks = syms[j].DynamicCast<SGPSymbiont>()->GetCPU().state.parent_tasks_performed->ToBinaryString();
-      if (emp::Has(parent_task_counts, sym_parent_tasks)) {
-        parent_task_counts[sym_parent_tasks].second++;
+      std::string sym_matching_tasks = (sgp_config->TRACK_PARENT_TASKS()) ?
+        syms[j].DynamicCast<SGPSymbiont>()->GetCPU().state.parent_tasks_performed->ToBinaryString() :
+        syms[j].DynamicCast<SGPSymbiont>()->GetCPU().state.tasks_performed->ToBinaryString();
+      if (emp::Has(matching_task_counts, sym_matching_tasks)) {
+        matching_task_counts[sym_matching_tasks][1]++;
       }
       else {
-        parent_task_counts[sym_parent_tasks] = std::pair<int, int>(0, 1);
+        matching_task_counts[sym_matching_tasks][1] = 1;// = { 0, 1, 0, 0 };
       }
     }
   }
 
+  // bits construction from string takes a loop, so just loop here
+  for (auto it = matching_task_counts.begin(); 
+    it != matching_task_counts.end(); it++){
+    for (auto interior_it = it; interior_it != matching_task_counts.end(); interior_it++) {
+      if (interior_it == it) continue;
+      // bit operation do and <- need to have keys be bitsets and not bitstrings
+      bool can_infect = false;
+
+      for (int i = CPU_BITSET_LENGTH - 1; i >= 0 && !can_infect; i--) {
+        if (it->first[i] == interior_it->first[i] && interior_it->first[i] == '1') {
+          std::cout << interior_it->first[i] << " , i: " << i << " , bitstring " << interior_it->first[i] << std::endl;
+          can_infect = true;
+        }
+      }
+      if (can_infect) {
+        // [2] counts [0] hosts which can infect, [3] counts [1] symbionts which can infect
+        it->second[2] += interior_it->second[0];
+        it->second[3] += interior_it->second[1];
+        interior_it->second[2] += it->second[0];
+        interior_it->second[3] += it->second[1];
+      }
+
+    }
+  }
+
+
   // write all the combinations and counts to the data file
-  out_file << "parent_task_completions,host_count,symbiont_count\n";
-  for (auto& key_value : parent_task_counts) {
+  out_file << "parent_task_completions,host_count,symbiont_count,can_inf_hosts,can_inf_symbionts\n";
+  for (auto& key_value : matching_task_counts) {
     // each "key_value" is a bitstring key with a pair (int,int) value
-    out_file << key_value.first << "," << std::to_string(key_value.second.first) << "," << std::to_string(key_value.second.second) << "\n";
+    out_file << key_value.first << "," << std::to_string(key_value.second[0]) << ",";
+    out_file << std::to_string(key_value.second[1]) << ',' << std::to_string(key_value.second[2]);
+    out_file << ',' << std::to_string(key_value.second[3]) << "\n";
   }
 
   out_file.close();

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -156,7 +156,6 @@ void SGPWorld::WriteTaskCombinationsFile(const std::string& filename) {
 
       for (int i = CPU_BITSET_LENGTH - 1; i >= 0 && !can_infect; i--) {
         if (it->first[i] == interior_it->first[i] && interior_it->first[i] == '1') {
-          std::cout << interior_it->first[i] << " , i: " << i << " , bitstring " << interior_it->first[i] << std::endl;
           can_infect = true;
         }
       }
@@ -195,14 +194,34 @@ void SGPWorld::WriteTaskCombinationsFile(const std::string& filename) {
  */
 void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
   std::ofstream out_file(filename);
-  out_file << "org_type,repro_count\n";
+  out_file << "org_type,repro_count";
+  for (auto task : task_set) {
+    out_file << ",gained_count_" << task.task.name << ",lost_count_" << task.task.name;
+  }
+  out_file << "\n";
+
+  emp::Ptr<SGPHost> host;
+  emp::Ptr<SGPSymbiont> symbiont;
+
   for (int i = 0; i < size(); i++) {
     if (IsOccupied(i)) {
-      out_file << "host," << pop[i].DynamicCast<SGPHost>()->GetReproCount() << "\n";
-      if (pop[i]->HasSym()) {
-        emp::vector<emp::Ptr<Organism>> syms = pop[i]->GetSymbionts();
+      host = pop[i].DynamicCast<SGPHost>();
+      out_file << "host," << host->GetReproCount();
+      for (int k = 0; k < CPU_BITSET_LENGTH; k++) {
+        out_file << "," << host->GetCPU().state.task_change_gain[k] << "," << host->GetCPU().state.task_change_lose[k];
+      }
+      out_file << "\n";
+
+      if (host->HasSym()) {
+        emp::vector<emp::Ptr<Organism>> syms = host->GetSymbionts();
         for (size_t j = 0; j < syms.size(); j++) {
-          out_file << "sym," << syms[j].DynamicCast<SGPSymbiont>()->GetReproCount() << "\n";
+          symbiont = syms[j].DynamicCast<SGPSymbiont>();
+
+          out_file << "sym," << symbiont->GetReproCount();
+          for (int k = 0; k < CPU_BITSET_LENGTH; k++) {
+            out_file << "," << symbiont->GetCPU().state.task_change_gain[k] << "," << symbiont->GetCPU().state.task_change_lose[k];
+          }
+          out_file << "\n";
         }
       }
     }

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -196,7 +196,7 @@ void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
   std::ofstream out_file(filename);
   out_file << "org_type,repro_count";
   for (auto task : task_set) {
-    out_file << ",gained_count_" << task.task.name << ",lost_count_" << task.task.name;
+    out_file << ",lineage_gained_count_" << task.task.name << ",lineage_lost_count_" << task.task.name << ",toward_partner_count_" << task.task.name << ",toward_partner_count_" << task.task.name;
   }
   out_file << "\n";
 
@@ -208,7 +208,7 @@ void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
       host = pop[i].DynamicCast<SGPHost>();
       out_file << "host," << host->GetReproCount();
       for (int k = 0; k < CPU_BITSET_LENGTH; k++) {
-        out_file << "," << host->GetCPU().state.task_change_gain[k] << "," << host->GetCPU().state.task_change_lose[k];
+        out_file << "," << host->GetCPU().state.task_change_gain[k] << "," << host->GetCPU().state.task_change_lose[k] << "," << host->GetCPU().state.task_toward_partner[k] << "," << host->GetCPU().state.task_from_partner[k];
       }
       out_file << "\n";
 
@@ -219,7 +219,7 @@ void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
 
           out_file << "sym," << symbiont->GetReproCount();
           for (int k = 0; k < CPU_BITSET_LENGTH; k++) {
-            out_file << "," << symbiont->GetCPU().state.task_change_gain[k] << "," << symbiont->GetCPU().state.task_change_lose[k];
+            out_file << "," << symbiont->GetCPU().state.task_change_gain[k] << "," << symbiont->GetCPU().state.task_change_lose[k] << "," << symbiont->GetCPU().state.task_toward_partner[k] << "," << symbiont->GetCPU().state.task_from_partner[k];
           }
           out_file << "\n";
         }

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -203,7 +203,7 @@ void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
   emp::Ptr<SGPHost> host;
   emp::Ptr<SGPSymbiont> symbiont;
 
-  for (int i = 0; i < size(); i++) {
+  for (size_t i = 0; i < size(); i++) {
     if (IsOccupied(i)) {
       host = pop[i].DynamicCast<SGPHost>();
       out_file << "host," << host->GetReproCount();

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -196,7 +196,7 @@ void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
   std::ofstream out_file(filename);
   out_file << "org_type,repro_count";
   for (auto task : task_set) {
-    out_file << ",lineage_gained_count_" << task.task.name << ",lineage_lost_count_" << task.task.name << ",toward_partner_count_" << task.task.name << ",toward_partner_count_" << task.task.name;
+    out_file << ",lineage_gained_count_" << task.task.name << ",lineage_lost_count_" << task.task.name << ",toward_partner_count_" << task.task.name << ",from_partner_count_" << task.task.name;
   }
   out_file << "\n";
 

--- a/source/sgp_mode/SGPDataNodes.h
+++ b/source/sgp_mode/SGPDataNodes.h
@@ -184,6 +184,34 @@ void SGPWorld::WriteTaskCombinationsFile(const std::string& filename) {
   out_file.close();
 }
 
+/**
+ * Input: The address of the string representing the file to be
+ * created's name
+ *
+ * Output: None
+ *
+ * Purpose: To write the reproductive and mutation history 
+ * of all hosts and symbionts
+ */
+void SGPWorld::WriteOrgReproHistFile(const std::string& filename) {
+  std::ofstream out_file(filename);
+  out_file << "org_type,repro_count\n";
+  for (int i = 0; i < size(); i++) {
+    if (IsOccupied(i)) {
+      out_file << "host," << pop[i].DynamicCast<SGPHost>()->GetReproCount() << "\n";
+      if (pop[i]->HasSym()) {
+        emp::vector<emp::Ptr<Organism>> syms = pop[i]->GetSymbionts();
+        for (size_t j = 0; j < syms.size(); j++) {
+          out_file << "sym," << syms[j].DynamicCast<SGPSymbiont>()->GetReproCount() << "\n";
+        }
+      }
+    }
+  }
+
+  out_file.close();
+}
+
+
 void SGPWorld::SetupTasksNodes() {
   if (!data_node_host_tasks.size()) {
     data_node_host_tasks.resize(task_set.NumTasks());

--- a/source/sgp_mode/SGPHost.cc
+++ b/source/sgp_mode/SGPHost.cc
@@ -14,7 +14,7 @@
 */
 emp::Ptr<Organism> SGPHost::Reproduce() {
   emp::Ptr<SGPHost> host_baby = Host::Reproduce().DynamicCast<SGPHost>();
-  host_baby->IncrementReproCount();
+  host_baby->SetReproCount(reproductions + 1);
   // This organism is reproducing, so it must have gotten off the queue
   cpu.state.in_progress_repro = -1;
   if (sgp_config->TRACK_PARENT_TASKS()) {

--- a/source/sgp_mode/SGPHost.cc
+++ b/source/sgp_mode/SGPHost.cc
@@ -1,0 +1,69 @@
+#ifndef SGP_HOST_C
+#define SGP_HOST_C
+
+#include "SGPHost.h"
+#include "SGPSymbiont.h"
+
+
+/**
+* Input: None.
+*
+* Output: A new host baby of the current host, mutated.
+*
+* Purpose: To create a new baby host and reset this host's points to 0.
+*/
+emp::Ptr<Organism> SGPHost::Reproduce() {
+  emp::Ptr<SGPHost> host_baby = Host::Reproduce().DynamicCast<SGPHost>();
+  host_baby->IncrementReproCount();
+  // This organism is reproducing, so it must have gotten off the queue
+  cpu.state.in_progress_repro = -1;
+  if (sgp_config->TRACK_PARENT_TASKS()) {
+    host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
+
+    for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+      // lineage task gain / loss
+      if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
+        // child gains the ability to be infected by syms whose parents have done this task
+        host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+        host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i] + 1;
+      }
+      else if (!cpu.state.tasks_performed->Get(i) && cpu.state.parent_tasks_performed->Get(i)) {
+        // child loses the ability to be infected by syms with whom this parent had only this task in common 
+        host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
+        host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+      }
+      else {
+        host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+        host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+      }
+
+      // divergence from/convergence towards parent's partner
+      if (HasSym()) {
+        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> symbiont_tasks = syms[0].DynamicCast<SGPSymbiont>()->GetCPU().state.parent_tasks_performed;
+        if (cpu.state.parent_tasks_performed->Get(i) != symbiont_tasks->Get(i) &&
+          cpu.state.tasks_performed->Get(i) == symbiont_tasks->Get(i)) {
+          // parent != partner and child == partner
+          // toward partner
+          host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+          host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i] + 1;
+        }
+        else if (cpu.state.parent_tasks_performed->Get(i) == symbiont_tasks->Get(i) &&
+          cpu.state.tasks_performed->Get(i) != symbiont_tasks->Get(i)) {
+          // parent == partner and child != partner
+          // away from partner
+          host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i] + 1;
+          host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
+        }
+        else {
+          // no change
+          host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+          host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
+        }
+      }
+    }
+  }
+  return host_baby;
+}
+
+
+#endif

--- a/source/sgp_mode/SGPHost.cc
+++ b/source/sgp_mode/SGPHost.cc
@@ -21,43 +21,32 @@ emp::Ptr<Organism> SGPHost::Reproduce() {
     host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
 
     for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+      host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+      host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
       // lineage task gain / loss
       if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
         // child gains the ability to be infected by syms whose parents have done this task
-        host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
         host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i] + 1;
       }
       else if (!cpu.state.tasks_performed->Get(i) && cpu.state.parent_tasks_performed->Get(i)) {
         // child loses the ability to be infected by syms with whom this parent had only this task in common 
         host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
-        host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
-      }
-      else {
-        host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
-        host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
       }
 
       // divergence from/convergence towards parent's partner
+      host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+      host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
       if (HasSym()) {
         emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> symbiont_tasks = syms[0].DynamicCast<SGPSymbiont>()->GetCPU().state.parent_tasks_performed;
         if (cpu.state.parent_tasks_performed->Get(i) != symbiont_tasks->Get(i) &&
           cpu.state.tasks_performed->Get(i) == symbiont_tasks->Get(i)) {
           // parent != partner and child == partner
-          // toward partner
-          host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
           host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i] + 1;
         }
         else if (cpu.state.parent_tasks_performed->Get(i) == symbiont_tasks->Get(i) &&
           cpu.state.tasks_performed->Get(i) != symbiont_tasks->Get(i)) {
           // parent == partner and child != partner
-          // away from partner
           host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i] + 1;
-          host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
-        }
-        else {
-          // no change
-          host_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
-          host_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
         }
       }
     }

--- a/source/sgp_mode/SGPHost.h
+++ b/source/sgp_mode/SGPHost.h
@@ -181,40 +181,8 @@ public:
     GrowOlder();
   }
 
-  /**
-  * Input: None.
-  *
-  * Output: A new host baby of the current host, mutated.
-  *
-  * Purpose: To create a new baby host and reset this host's points to 0.
-  */
-  emp::Ptr<Organism> Reproduce() {
-    emp::Ptr<SGPHost> host_baby = Host::Reproduce().DynamicCast<SGPHost>();
-    host_baby->IncrementReproCount();
-    // This organism is reproducing, so it must have gotten off the queue
-    cpu.state.in_progress_repro = -1;
-    if (sgp_config->TRACK_PARENT_TASKS()) {
-      host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
-
-      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
-        if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
-          // child gains the ability to be infected by syms whose parents have done this task
-          host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
-          host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i] + 1;
-        }
-        else if (!cpu.state.tasks_performed->Get(i) && cpu.state.parent_tasks_performed->Get(i)) {
-          // child loses the ability to be infected by syms with whom this parent had only this task in common 
-          host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
-          host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
-        }
-        else {
-          host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
-          host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
-        }
-      }
-    }
-    return host_baby;
-  }
+  // Prototype for this host's reproduce method
+  emp::Ptr<Organism> Reproduce();
 
   /**
    * Input: None.

--- a/source/sgp_mode/SGPHost.h
+++ b/source/sgp_mode/SGPHost.h
@@ -101,13 +101,13 @@ public:
   }
 
   /**
-   * Input: Increment the reproduction counter
+   * Input: Set the reproduction counter
    *
    * Output: None
    *
-   * Purpose: To increase the count of reproductions in this lineage by one.
+   * Purpose: To set the count of reproductions in this lineage.
    */
-  void IncrementReproCount() { reproductions++; }
+  void SetReproCount(int _in) { reproductions = _in; }
 
   /**
    * Input: None.

--- a/source/sgp_mode/SGPHost.h
+++ b/source/sgp_mode/SGPHost.h
@@ -195,6 +195,23 @@ public:
     cpu.state.in_progress_repro = -1;
     if (sgp_config->TRACK_PARENT_TASKS()) {
       host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
+
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
+          // child gains the ability to be infected by syms whose parents have done this task
+          host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+          host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i] + 1;
+        }
+        else if (!cpu.state.tasks_performed->Get(i) && cpu.state.parent_tasks_performed->Get(i)) {
+          // child loses the ability to be infected by syms with whom this parent had only this task in common 
+          host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
+          host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+        }
+        else {
+          host_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+          host_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+        }
+      }
     }
     return host_baby;
   }

--- a/source/sgp_mode/SGPHost.h
+++ b/source/sgp_mode/SGPHost.h
@@ -69,7 +69,6 @@ public:
    */
   ~SGPHost() {
     cpu.state.used_resources.Delete();
-    cpu.state.tasks_performed.Delete();
     cpu.state.shared_available_dependencies.Delete();
     cpu.state.internal_environment.Delete();
     // Invalidate any in-progress reproduction
@@ -170,6 +169,9 @@ public:
         random, my_world, sgp_config, cpu.GetProgram(), GetIntVal());
     // This organism is reproducing, so it must have gotten off the queue
     cpu.state.in_progress_repro = -1;
+    if (sgp_config->TRACK_PARENT_TASKS()) {
+      host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed); 
+    }
     return host_baby;
   }
 

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -227,19 +227,21 @@ public:
           sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
         }
 
-        // divergence from/convergence towards parent's partner
-        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = my_host.DynamicCast<SGPHost>()->GetCPU().state.parent_tasks_performed;
-        sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
-        sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
-        if (cpu.state.parent_tasks_performed->Get(i) != host_tasks->Get(i) &&
-          cpu.state.tasks_performed->Get(i) == host_tasks->Get(i)) {
-          // parent != partner and child == partner
-          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i] + 1;
-        }
-        else if (cpu.state.parent_tasks_performed->Get(i) == host_tasks->Get(i) &&
-          cpu.state.tasks_performed->Get(i) != host_tasks->Get(i)) {
-          // parent == partner and child != partner
-          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i] + 1;
+        if (my_host) {
+          // divergence from/convergence towards parent's partner
+          emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = my_host.DynamicCast<SGPHost>()->GetCPU().state.parent_tasks_performed;
+          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
+          if (cpu.state.parent_tasks_performed->Get(i) != host_tasks->Get(i) &&
+            cpu.state.tasks_performed->Get(i) == host_tasks->Get(i)) {
+            // parent != partner and child == partner
+            sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i] + 1;
+          }
+          else if (cpu.state.parent_tasks_performed->Get(i) == host_tasks->Get(i) &&
+            cpu.state.tasks_performed->Get(i) != host_tasks->Get(i)) {
+            // parent == partner and child != partner
+            sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i] + 1;
+          }
         }
       }
     }

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -96,13 +96,13 @@ public:
   }
 
   /**
-   * Input: Increment the reproduction counter
+   * Input: Set the reproduction counter
    *
    * Output: None
    *
-   * Purpose: To increase the count of reproductions in this lineage by one.
+   * Purpose: To set the count of reproductions in this lineage.
    */
-  void IncrementReproCount() { reproductions++; }
+  void SetReproCount(int _in) { reproductions = _in; }
  
   /**
    * Input: None.
@@ -207,7 +207,7 @@ public:
    */
   emp::Ptr<Organism> Reproduce() {
     emp::Ptr<SGPSymbiont> sym_baby = Symbiont::Reproduce().DynamicCast<SGPSymbiont>();
-    sym_baby->IncrementReproCount();
+    sym_baby->SetReproCount(reproductions + 1);
     // This organism is reproducing, so it must have gotten off the queue
     cpu.state.in_progress_repro = -1;
     if (sgp_config->TRACK_PARENT_TASKS()) {

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -60,7 +60,6 @@ public:
    * heap-allocated state and canceling any in-progress reproduction.
    */
   ~SGPSymbiont() {
-    cpu.state.tasks_performed.Delete();
     if (!my_host) {
       cpu.state.internal_environment.Delete();
       cpu.state.used_resources.Delete();
@@ -185,6 +184,9 @@ public:
         random, my_world, sgp_config, cpu.GetProgram(), GetIntVal());
     // This organism is reproducing, so it must have gotten off the queue
     cpu.state.in_progress_repro = -1;
+    if (sgp_config->TRACK_PARENT_TASKS()) {
+      sym_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
+    }
     return sym_baby;
   }
 

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -216,41 +216,30 @@ public:
       for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
 
         // lineage task gain / loss
+        sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+        sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
         if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
           // child gains the ability to infect hosts whose parents have done this task
-          sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
           sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i] + 1;
         }
         else if (!cpu.state.tasks_performed->Get(i) && cpu.state.parent_tasks_performed->Get(i)) {
           // child loses the ability to infect hosts with whom this parent had only this task in common 
           sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
-          sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
-        }
-        else {
-          sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
-          sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
         }
 
         // divergence from/convergence towards parent's partner
         emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = my_host.DynamicCast<SGPHost>()->GetCPU().state.parent_tasks_performed;
+        sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+        sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
         if (cpu.state.parent_tasks_performed->Get(i) != host_tasks->Get(i) &&
           cpu.state.tasks_performed->Get(i) == host_tasks->Get(i)) {
           // parent != partner and child == partner
-          // toward partner
-          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
           sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i] + 1;
         }
         else if (cpu.state.parent_tasks_performed->Get(i) == host_tasks->Get(i) &&
           cpu.state.tasks_performed->Get(i) != host_tasks->Get(i)) {
           // parent == partner and child != partner
-          // away from partner
           sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i] + 1;
-          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
-        }
-        else {
-          // no change
-          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
-          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
         }
       }
     }

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -212,6 +212,23 @@ public:
     cpu.state.in_progress_repro = -1;
     if (sgp_config->TRACK_PARENT_TASKS()) {
       sym_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
+      //inherit towards-from tracking
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
+          // child gains the ability to infect hosts whose parents have done this task
+          sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+          sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i] + 1;
+        }
+        else if (!cpu.state.tasks_performed->Get(i) && cpu.state.parent_tasks_performed->Get(i)) {
+          // child loses the ability to infect hosts with whom this parent had only this task in common 
+          sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i] + 1;
+          sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+        }
+        else {
+          sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
+          sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+        }
+      }
     }
     return sym_baby;
   }

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -12,6 +12,13 @@ private:
   CPU cpu;
   const emp::Ptr<SGPWorld> my_world;
 
+  /**
+   *
+   * Purpose: Tracks the number of reproductive events in this symbiont's lineage.
+   *
+   */
+  unsigned int reproductions = 0;
+
 protected:
   /**
    * 
@@ -89,7 +96,25 @@ public:
   }
 
   /**
-   * Input: The pointer to an organism that will be set as the symbinot's host
+   * Input: Increment the reproduction counter
+   *
+   * Output: None
+   *
+   * Purpose: To increase the count of reproductions in this lineage by one.
+   */
+  void IncrementReproCount() { reproductions++; }
+ 
+  /**
+   * Input: None.
+   *
+   * Output: The reproduction count
+   *
+   * Purpose: To get the count of reproductions in this lineage.
+   */
+  unsigned int GetReproCount() { return reproductions; }
+
+  /**
+   * Input: The pointer to an organism that will be set as the symbiont's host
    *
    * Output: None
    *
@@ -172,6 +197,26 @@ public:
     cpu.state.in_progress_repro = old;
   }
 
+
+  /**
+   * Input: None
+   *
+   * Output: The pointer to the newly created organism
+   *
+   * Purpose: To produce a new SGPSymbiont
+   */
+  emp::Ptr<Organism> Reproduce() {
+    emp::Ptr<SGPSymbiont> sym_baby = Symbiont::Reproduce().DynamicCast<SGPSymbiont>();
+    sym_baby->IncrementReproCount();
+    // This organism is reproducing, so it must have gotten off the queue
+    cpu.state.in_progress_repro = -1;
+    if (sgp_config->TRACK_PARENT_TASKS()) {
+      sym_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
+    }
+    return sym_baby;
+  }
+
+
   /**
    * Input: None
    *
@@ -182,11 +227,6 @@ public:
   emp::Ptr<Organism> MakeNew() {
     emp::Ptr<SGPSymbiont> sym_baby = emp::NewPtr<SGPSymbiont>(
         random, my_world, sgp_config, cpu.GetProgram(), GetIntVal());
-    // This organism is reproducing, so it must have gotten off the queue
-    cpu.state.in_progress_repro = -1;
-    if (sgp_config->TRACK_PARENT_TASKS()) {
-      sym_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
-    }
     return sym_baby;
   }
 

--- a/source/sgp_mode/SGPSymbiont.h
+++ b/source/sgp_mode/SGPSymbiont.h
@@ -214,6 +214,8 @@ public:
       sym_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
       //inherit towards-from tracking
       for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+
+        // lineage task gain / loss
         if (cpu.state.tasks_performed->Get(i) && !cpu.state.parent_tasks_performed->Get(i)) {
           // child gains the ability to infect hosts whose parents have done this task
           sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
@@ -227,6 +229,28 @@ public:
         else {
           sym_baby->GetCPU().state.task_change_lose[i] = cpu.state.task_change_lose[i];
           sym_baby->GetCPU().state.task_change_gain[i] = cpu.state.task_change_gain[i];
+        }
+
+        // divergence from/convergence towards parent's partner
+        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = my_host.DynamicCast<SGPHost>()->GetCPU().state.parent_tasks_performed;
+        if (cpu.state.parent_tasks_performed->Get(i) != host_tasks->Get(i) &&
+          cpu.state.tasks_performed->Get(i) == host_tasks->Get(i)) {
+          // parent != partner and child == partner
+          // toward partner
+          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i] + 1;
+        }
+        else if (cpu.state.parent_tasks_performed->Get(i) == host_tasks->Get(i) &&
+          cpu.state.tasks_performed->Get(i) != host_tasks->Get(i)) {
+          // parent == partner and child != partner
+          // away from partner
+          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i] + 1;
+          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
+        }
+        else {
+          // no change
+          sym_baby->GetCPU().state.task_from_partner[i] = cpu.state.task_from_partner[i];
+          sym_baby->GetCPU().state.task_toward_partner[i] = cpu.state.task_toward_partner[i];
         }
       }
     }

--- a/source/sgp_mode/SGPWorld.h
+++ b/source/sgp_mode/SGPWorld.h
@@ -179,6 +179,7 @@ public:
   emp::DataFile &SetUpOrgCountFile(const std::string &filename);
   emp::DataFile &SetupSymDonatedFile(const std::string &filename);
   emp::DataFile &SetupTasksFile(const std::string &filename);
+  void WriteTaskCombinationsFile(const std::string& filename);
 
   void CreateDataFiles() override;
 };

--- a/source/sgp_mode/SGPWorld.h
+++ b/source/sgp_mode/SGPWorld.h
@@ -164,10 +164,12 @@ public:
   void SetupHosts(long unsigned int *POP_SIZE) override;
   void SetupSymbionts(long unsigned int *total_syms) override;
 
-  
+  // Prototypes for reproduction handling methods
   emp::WorldPosition SymDoBirth(emp::Ptr<Organism> sym_baby, emp::WorldPosition parent_pos) override;
-  int GetNeighborHost (size_t id, emp::Ptr<Organism> symbiont);
+  int GetNeighborHost(size_t id, emp::Ptr<Organism> symbiont);
   bool TaskMatchCheck(emp::Ptr<Organism> sym_parent, emp::Ptr<Organism> host_parent);
+
+  // Prototype for graveyard handling method
   void SendToGraveyard(emp::Ptr<Organism> org) override;
 
   // Prototypes for data node methods

--- a/source/sgp_mode/SGPWorld.h
+++ b/source/sgp_mode/SGPWorld.h
@@ -180,6 +180,7 @@ public:
   emp::DataFile &SetupSymDonatedFile(const std::string &filename);
   emp::DataFile &SetupTasksFile(const std::string &filename);
   void WriteTaskCombinationsFile(const std::string& filename);
+  void WriteOrgReproHistFile(const std::string& filename);
 
   void CreateDataFiles() override;
 };

--- a/source/sgp_mode/SGPWorldSetup.cc
+++ b/source/sgp_mode/SGPWorldSetup.cc
@@ -81,8 +81,16 @@ int SGPWorld::GetNeighborHost (size_t id, emp::Ptr<Organism> symbiont){
   * Purpose: To check for task matching before vertical transmission
   */
 bool SGPWorld::TaskMatchCheck(emp::Ptr<Organism> sym_parent, emp::Ptr<Organism> host_parent) {
-  emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks = sym_parent.DynamicCast<SGPSymbiont>()->GetCPU().state.tasks_performed;
-  emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = host_parent.DynamicCast<SGPHost>()->GetCPU().state.tasks_performed;
+  emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks;
+  emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks;
+  if (sgp_config->TRACK_PARENT_TASKS()) {
+    parent_tasks = sym_parent.DynamicCast<SGPSymbiont>()->GetCPU().state.parent_tasks_performed;
+    host_tasks = host_parent.DynamicCast<SGPHost>()->GetCPU().state.parent_tasks_performed;
+  }
+  else {
+    parent_tasks = sym_parent.DynamicCast<SGPSymbiont>()->GetCPU().state.tasks_performed;
+    host_tasks = host_parent.DynamicCast<SGPHost>()->GetCPU().state.tasks_performed;
+  }
   for (int i = host_tasks->size() - 1; i > -1; i--) {
     if (parent_tasks->Get(i) && host_tasks->Get(i)) {
       //both parent sym and host can do this task, symbiont baby can infect

--- a/source/sgp_mode/StressHost.h
+++ b/source/sgp_mode/StressHost.h
@@ -43,11 +43,6 @@ public:
   emp::Ptr<Organism> MakeNew() override {
     emp::Ptr<SGPHost> host_baby = emp::NewPtr<StressHost>(
       random, GetWorld(), sgp_config, GetCPU().GetProgram(), GetIntVal());
-    // This organism is reproducing, so it must have gotten off the queue
-    GetCPU().state.in_progress_repro = -1;
-    if (sgp_config->TRACK_PARENT_TASKS()) {
-      host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
-    }
     return host_baby;
   }
 

--- a/source/sgp_mode/StressHost.h
+++ b/source/sgp_mode/StressHost.h
@@ -45,6 +45,9 @@ public:
       random, GetWorld(), sgp_config, GetCPU().GetProgram(), GetIntVal());
     // This organism is reproducing, so it must have gotten off the queue
     GetCPU().state.in_progress_repro = -1;
+    if (sgp_config->TRACK_PARENT_TASKS()) {
+      host_baby->GetCPU().state.parent_tasks_performed->Import(*GetCPU().state.tasks_performed);
+    }
     return host_baby;
   }
 

--- a/source/sgp_mode/StressHost.h
+++ b/source/sgp_mode/StressHost.h
@@ -28,9 +28,9 @@ public:
     double _intval = 0.0, emp::vector<emp::Ptr<Organism>> _syms = {},
     emp::vector<emp::Ptr<Organism>> _repro_syms = {},
     double _points = 0.0)
-    : SGPHost(_random, _world, _config, _intval, _syms, _repro_syms, _points) {}
+    : SGPHost(_random, _world, _config, genome, _intval, _syms, _repro_syms, _points) {}
 
-  StressHost(const SGPHost& host)
+  StressHost(const StressHost& host)
     : SGPHost(host) {}
 
   /**
@@ -41,7 +41,7 @@ public:
    * Purpose: To avoid creating an organism via constructor in other methods.
    */
   emp::Ptr<Organism> MakeNew() override {
-    emp::Ptr<SGPHost> host_baby = emp::NewPtr<StressHost>(
+    emp::Ptr<StressHost> host_baby = emp::NewPtr<StressHost>(
       random, GetWorld(), sgp_config, GetCPU().GetProgram(), GetIntVal());
     return host_baby;
   }

--- a/source/sgp_mode/Tasks.cc
+++ b/source/sgp_mode/Tasks.cc
@@ -1,3 +1,6 @@
+#ifndef TASKS_C
+#define TASKS_C
+
 #include "Tasks.h"
 #include "SGPWorld.h"
 
@@ -31,3 +34,5 @@ void Task::MarkPerformed(CPUState &state, uint32_t output, size_t task_id,
     state.available_dependencies[task_id]++;
   }
 }
+
+#endif

--- a/source/sgp_mode/Tasks.h
+++ b/source/sgp_mode/Tasks.h
@@ -116,10 +116,10 @@ class TaskSet {
 
   float MarkPerformedTask(CPUState &state, uint32_t output, size_t task_id,
                           bool shared, float score) {
-    if (state.tasks_performed->Get(task_id)){
-      //Half points if they did the task before, pushing them to do more tasks instead of cycling
-      score = score/2.0;
-    }
+    //if (state.tasks_performed->Get(task_id)){
+    //  //Half points if they did the task before, pushing them to do more tasks instead of cycling
+    //  score = score/2.0;
+    //}
     if (state.organism->IsHost()){
       score = state.world.Cast<SymWorld>()->PullResources(score);
     }

--- a/source/test/sgp_mode_test/CPU.test.cc
+++ b/source/test/sgp_mode_test/CPU.test.cc
@@ -44,6 +44,5 @@ TEST_CASE("Ancestor CPU can reproduce", "[sgp]") {
     cpu.state.shared_available_dependencies.Delete();
     cpu.state.used_resources.Delete();
     cpu.state.internal_environment.Delete();
-    cpu.state.tasks_performed.Delete();
   }
 }

--- a/source/test/sgp_mode_test/GenomeLibrary.test.cc
+++ b/source/test/sgp_mode_test/GenomeLibrary.test.cc
@@ -36,7 +36,6 @@ void TestGenome(emp::Ptr<Task> task, void (ProgramBuilder::*method)()) {
   cpu.state.shared_available_dependencies.Delete();
   cpu.state.used_resources.Delete();
   cpu.state.internal_environment.Delete();
-  cpu.state.tasks_performed.Delete();
 }
 
 TEST_CASE("Generate NOT program", "[sgp]") {
@@ -99,5 +98,4 @@ TEST_CASE("Empty ProgramBuilder can't do tasks", "[sgp]") {
   cpu.state.shared_available_dependencies.Delete();
   cpu.state.used_resources.Delete();
   cpu.state.internal_environment.Delete();
-  cpu.state.tasks_performed.Delete();
 }

--- a/source/test/sgp_mode_test/HealthHost.test.cc
+++ b/source/test/sgp_mode_test/HealthHost.test.cc
@@ -1,0 +1,49 @@
+#include "../../sgp_mode/HealthHost.h"
+
+TEST_CASE("Health hosts evolve", "[sgp]") {
+  emp::Random random(32);
+  SymConfigSGP config;
+  config.ORGANISM_TYPE(HEALTH);
+  config.START_MOI(0);
+  config.GRID_X(10);
+  config.GRID_Y(100);
+  config.HOST_REPRO_RES(20);
+  size_t world_size = config.GRID_X() * config.GRID_Y();
+
+  SGPWorld world(random, &config, LogicTasks);
+  world.SetupHosts(&world_size);
+
+  REQUIRE(world.GetNumOrgs() == world_size);
+
+  size_t no_mut_NOT_rate = 600000;
+
+  size_t run_updates = 15000;
+
+  WHEN("Mutation size is 0") {
+    config.MUTATION_SIZE(0); //  chance
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Health hosts do not accrue mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host == 0);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host == no_mut_NOT_rate);
+    }
+  }
+
+  WHEN("Mutation size is greater than 0") {
+    config.MUTATION_SIZE(0.0002);
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Health hosts accrue more mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host > 30);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 2);
+    }
+  }
+} 

--- a/source/test/sgp_mode_test/SGPHost.test.cc
+++ b/source/test/sgp_mode_test/SGPHost.test.cc
@@ -1,4 +1,5 @@
 #include "../../sgp_mode/SGPHost.h"
+#include "../../sgp_mode/SGPHost.cc"
 #include "../../sgp_mode/SGPWorld.h"
 #include "../../sgp_mode/SGPWorldSetup.cc"
 #include "../../sgp_mode/SGPDataNodes.h"
@@ -81,7 +82,7 @@ TEST_CASE("SGPHost Reproduce", "[sgp]") {
   SymConfigSGP config;
   SGPWorld world(random, &config, LogicTasks);
   emp::Ptr<SGPHost> host_parent = emp::NewPtr<SGPHost>(&random, &world, &config, CreateNotProgram(100));
-  
+  world.AddOrgAt(host_parent, 0);
 
   THEN("Host child increases its lineage reproduction count") {
     emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
@@ -91,18 +92,60 @@ TEST_CASE("SGPHost Reproduce", "[sgp]") {
 
   WHEN("Parental task tracking is on") {
     config.TRACK_PARENT_TASKS(1);
-    emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
-    THEN("Host child inherits its parent's completed task bitset") {
-      REQUIRE(host_parent->GetCPU().state.parent_tasks_performed->All());
-      REQUIRE(host_parent->GetCPU().state.tasks_performed->None());
-      REQUIRE(host_baby->GetCPU().state.parent_tasks_performed->None());
+
+    for (int i = 0; i < 25; i++) {
+      world.Update();
     }
-    host_baby.Delete();
-  }
+    
+    THEN("Host child inherits its parent's completed task bitset") {
+      emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
+      REQUIRE(host_parent->GetCPU().state.parent_tasks_performed->All());
 
-  host_parent.Delete();
-}
+      REQUIRE(host_parent->GetCPU().state.tasks_performed->Get(0));
+      REQUIRE(host_parent->GetCPU().state.tasks_performed->CountOnes() == 1);
 
-TEST_CASE("SGPHost track divergence from parent & from parent's partner") {
-  REQUIRE(1 == 0);
+      REQUIRE(host_baby->GetCPU().state.parent_tasks_performed->Get(0));
+      REQUIRE(host_baby->GetCPU().state.parent_tasks_performed->CountOnes() == 1);
+      host_baby.Delete();
+    }
+
+    THEN("The host child tracks any gains or loses in task completions") {
+      emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
+      // in this second generation, we expect the host to lose every task except for NOT
+      // since first-gen organisms are uniquely marked as having parents who complete every task
+      
+      REQUIRE(host_baby->GetCPU().state.task_change_lose[0] == 0);
+      REQUIRE(host_baby->GetCPU().state.task_change_gain[0] == 0);
+      for (unsigned int i = 1; i < CPU_BITSET_LENGTH; i++) {
+        REQUIRE(host_baby->GetCPU().state.task_change_lose[i] == 1);
+        REQUIRE(host_baby->GetCPU().state.task_change_gain[i] == 0);
+      }
+      host_baby.Delete();
+    }
+    WHEN("The host parent has no symbiont") {
+      emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
+      THEN("The host child inherits the lineage's partner task flip count with no modifications"){
+        for (unsigned int i = 0; i < CPU_BITSET_LENGTH; i++) {
+          REQUIRE(host_baby->GetCPU().state.task_toward_partner[i] == 0);
+          REQUIRE(host_baby->GetCPU().state.task_from_partner[i] == 0);
+        }
+      }
+      host_baby.Delete();
+    }
+    WHEN("The host parent has a symbiont") {
+      host_parent->AddSymbiont(emp::NewPtr<SGPSymbiont>(&random, &world, &config, CreateNotProgram(100)));
+      emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
+      THEN("The host child tracks how its tasks compare to its parent's partner's tasks") {
+
+        REQUIRE(host_baby->GetCPU().state.task_toward_partner[0] == 0);
+        REQUIRE(host_baby->GetCPU().state.task_from_partner[0] == 0);
+
+        for (unsigned int i = 1; i < CPU_BITSET_LENGTH; i++) {
+          REQUIRE(host_baby->GetCPU().state.task_toward_partner[i] == 0);
+          REQUIRE(host_baby->GetCPU().state.task_from_partner[i] == 1);
+        }
+      }
+      host_baby.Delete();
+    }
+  } 
 }

--- a/source/test/sgp_mode_test/SGPHost.test.cc
+++ b/source/test/sgp_mode_test/SGPHost.test.cc
@@ -3,7 +3,7 @@
 #include "../../sgp_mode/SGPWorldSetup.cc"
 #include "../../sgp_mode/SGPDataNodes.h"
 
-TEST_CASE("SGPHost MakeNew parental task tracking", "[sgp]") {
+TEST_CASE("SGPHost Reproduce parental task tracking", "[sgp]") {
   emp::Random random(31);
   SymConfigSGP config;
   SGPWorld world(random, &config, LogicTasks);
@@ -11,6 +11,7 @@ TEST_CASE("SGPHost MakeNew parental task tracking", "[sgp]") {
   WHEN("Parental task tracking is on") {
     config.HOST_REPRO_RES(5000);
     config.MUTATION_RATE(0);
+    config.MUTATION_SIZE(0);
     config.TRACK_PARENT_TASKS(1);
     WHEN("A host can only perform NOT") {
       WHEN("It is of the first generation (does not have parents)") {
@@ -44,7 +45,7 @@ TEST_CASE("SGPHost MakeNew parental task tracking", "[sgp]") {
         for (int i = 0; i < 25; i++) {
           world.Update();
         }
-        emp::Ptr<SGPHost> host = (parent_host->MakeNew()).DynamicCast<SGPHost>();
+        emp::Ptr<SGPHost> host = (parent_host->Reproduce()).DynamicCast<SGPHost>();
 
         world.AddOrgAt(host, 0);
         REQUIRE(world.GetNumOrgs() == 1);
@@ -74,3 +75,31 @@ TEST_CASE("SGPHost MakeNew parental task tracking", "[sgp]") {
     }
   }
 }
+
+TEST_CASE("SGPHost Reproduce", "[sgp]") {
+  emp::Random random(31);
+  SymConfigSGP config;
+  SGPWorld world(random, &config, LogicTasks);
+  emp::Ptr<SGPHost> host_parent = emp::NewPtr<SGPHost>(&random, &world, &config, CreateNotProgram(100));
+  
+
+  THEN("Host child increases its lineage reproduction count") {
+    emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
+    REQUIRE(host_parent->GetReproCount() == host_baby->GetReproCount() - 1);
+    host_baby.Delete();
+  }
+
+  WHEN("Parental task tracking is on") {
+    config.TRACK_PARENT_TASKS(1);
+    emp::Ptr<SGPHost> host_baby = (host_parent->Reproduce()).DynamicCast<SGPHost>();
+    THEN("Host child inherits its parent's completed task bitset") {
+      REQUIRE(host_parent->GetCPU().state.parent_tasks_performed->All());
+      REQUIRE(host_parent->GetCPU().state.tasks_performed->None());
+      REQUIRE(host_baby->GetCPU().state.parent_tasks_performed->None());
+    }
+    host_baby.Delete();
+  }
+
+  host_parent.Delete();
+}
+

--- a/source/test/sgp_mode_test/SGPHost.test.cc
+++ b/source/test/sgp_mode_test/SGPHost.test.cc
@@ -103,3 +103,6 @@ TEST_CASE("SGPHost Reproduce", "[sgp]") {
   host_parent.Delete();
 }
 
+TEST_CASE("SGPHost track divergence from parent & from parent's partner") {
+  REQUIRE(1 == 0);
+}

--- a/source/test/sgp_mode_test/SGPHost.test.cc
+++ b/source/test/sgp_mode_test/SGPHost.test.cc
@@ -1,0 +1,76 @@
+#include "../../sgp_mode/SGPHost.h"
+#include "../../sgp_mode/SGPWorld.h"
+#include "../../sgp_mode/SGPWorldSetup.cc"
+#include "../../sgp_mode/SGPDataNodes.h"
+
+TEST_CASE("SGPHost MakeNew parental task tracking", "[sgp]") {
+  emp::Random random(31);
+  SymConfigSGP config;
+  SGPWorld world(random, &config, LogicTasks);
+  
+  WHEN("Parental task tracking is on") {
+    config.HOST_REPRO_RES(5000);
+    config.MUTATION_RATE(0);
+    config.TRACK_PARENT_TASKS(1);
+    WHEN("A host can only perform NOT") {
+      WHEN("It is of the first generation (does not have parents)") {
+        emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, CreateNotProgram(100));
+        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks = host->GetCPU().state.parent_tasks_performed;
+        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = host->GetCPU().state.tasks_performed;
+
+        world.AddOrgAt(host, 0);
+
+        THEN("Its own tasks are initially all marked as uncompleted") {
+          REQUIRE(host_tasks->None());
+        }
+        THEN("Its parent's tasks are all marked as successful") {
+          REQUIRE(parent_tasks->All());
+        }
+        for (int i = 0; i < 25; i++) {
+          world.Update();
+        }
+        THEN("After running for several updates, it is only tracked as completing NOT") {
+          // NOT id is 0 
+          REQUIRE(host_tasks->Get(0));
+          REQUIRE(host_tasks->CountOnes() == 1);
+
+          host_tasks->Toggle(1, CPU_BITSET_LENGTH);
+          REQUIRE(host_tasks->All());
+        }
+      }
+      WHEN("It has a parent who could only perform NOT") {
+        emp::Ptr<SGPHost> parent_host = emp::NewPtr<SGPHost>(&random, &world, &config, CreateNotProgram(100));
+        world.AddOrgAt(parent_host, 0);
+        for (int i = 0; i < 25; i++) {
+          world.Update();
+        }
+        emp::Ptr<SGPHost> host = (parent_host->MakeNew()).DynamicCast<SGPHost>();
+
+        world.AddOrgAt(host, 0);
+        REQUIRE(world.GetNumOrgs() == 1);
+        
+        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> host_tasks = host->GetCPU().state.tasks_performed;
+        emp::Ptr<emp::BitSet<CPU_BITSET_LENGTH>> parent_tasks = host->GetCPU().state.parent_tasks_performed;
+        
+        THEN("Its own tasks are initially all marked as uncompleted") {
+          REQUIRE(host_tasks->None());
+        }
+
+        for (int i = 0; i < 25; i++) {
+          world.Update();
+        }
+        
+        THEN("Only NOT is recorded are successful for its parent") {
+          REQUIRE(parent_tasks->Get(0));
+          REQUIRE(parent_tasks->CountOnes() == 1);
+          parent_tasks->Toggle(1, CPU_BITSET_LENGTH);
+          REQUIRE(parent_tasks->All());
+        }
+
+        THEN("It is only tracked as completing NOT") {
+          REQUIRE(host_tasks->Any());
+        }
+      }
+    }
+  }
+}

--- a/source/test/sgp_mode_test/SGPSymbiont.test.cc
+++ b/source/test/sgp_mode_test/SGPSymbiont.test.cc
@@ -30,3 +30,7 @@ TEST_CASE("SGPSymbiont Reproduce", "[sgp]") {
 	sym_parent.Delete();
 	
 }
+
+TEST_CASE("SGPSymbiont track divergence from parent & from parent's partner") {
+	REQUIRE(1 == 0);
+}

--- a/source/test/sgp_mode_test/SGPSymbiont.test.cc
+++ b/source/test/sgp_mode_test/SGPSymbiont.test.cc
@@ -1,0 +1,32 @@
+#include "../../sgp_mode/SGPHost.h"
+#include "../../sgp_mode/SGPWorld.h"
+#include "../../sgp_mode/SGPWorldSetup.cc"
+#include "../../sgp_mode/SGPDataNodes.h"
+
+TEST_CASE("SGPSymbiont Reproduce", "[sgp]") {
+	emp::Random random(31);
+	SymConfigSGP config;
+	SGPWorld world(random, &config, LogicTasks);
+	emp::Ptr<SGPSymbiont> sym_parent = emp::NewPtr<SGPSymbiont>(&random, &world, &config, CreateNotProgram(100));
+	
+
+	THEN("Symbiont child increases its lineage reproduction count"){
+		emp::Ptr<SGPSymbiont> sym_baby = (sym_parent->Reproduce()).DynamicCast<SGPSymbiont>();
+		REQUIRE(sym_parent->GetReproCount() == sym_baby->GetReproCount() - 1);
+		sym_baby.Delete();
+	}
+
+	WHEN("Parental task tracking is on") {
+		config.TRACK_PARENT_TASKS(1);
+		emp::Ptr<SGPSymbiont> sym_baby = (sym_parent->Reproduce()).DynamicCast<SGPSymbiont>();
+		THEN("Symbiont child inherits its parent's completed task bitset") {
+			REQUIRE(sym_parent->GetCPU().state.parent_tasks_performed->All());
+			REQUIRE(sym_parent->GetCPU().state.tasks_performed->None());
+			REQUIRE(sym_baby->GetCPU().state.parent_tasks_performed->None());
+		}
+		sym_baby.Delete();
+	}
+	
+	sym_parent.Delete();
+	
+}

--- a/source/test/sgp_mode_test/SGPSymbiont.test.cc
+++ b/source/test/sgp_mode_test/SGPSymbiont.test.cc
@@ -14,23 +14,52 @@ TEST_CASE("SGPSymbiont Reproduce", "[sgp]") {
 		emp::Ptr<SGPSymbiont> sym_baby = (sym_parent->Reproduce()).DynamicCast<SGPSymbiont>();
 		REQUIRE(sym_parent->GetReproCount() == sym_baby->GetReproCount() - 1);
 		sym_baby.Delete();
+    sym_parent.Delete();
 	}
 
-	WHEN("Parental task tracking is on") {
-		config.TRACK_PARENT_TASKS(1);
-		emp::Ptr<SGPSymbiont> sym_baby = (sym_parent->Reproduce()).DynamicCast<SGPSymbiont>();
-		THEN("Symbiont child inherits its parent's completed task bitset") {
-			REQUIRE(sym_parent->GetCPU().state.parent_tasks_performed->All());
-			REQUIRE(sym_parent->GetCPU().state.tasks_performed->None());
-			REQUIRE(sym_baby->GetCPU().state.parent_tasks_performed->None());
-		}
-		sym_baby.Delete();
-	}
-	
-	sym_parent.Delete();
-	
-}
+  WHEN("Parental task tracking is on") {
 
-TEST_CASE("SGPSymbiont track divergence from parent & from parent's partner") {
-	REQUIRE(1 == 0);
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, CreateNotProgram(100));
+    config.TRACK_PARENT_TASKS(1);
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym_parent);
+
+    for (int i = 0; i < 25; i++) {
+      world.Update();
+    }
+
+    emp::Ptr<SGPSymbiont> sym_baby = (sym_parent->Reproduce()).DynamicCast<SGPSymbiont>();
+
+    THEN("Symbiont child inherits its parent's completed task bitset") {
+      REQUIRE(sym_parent->GetCPU().state.parent_tasks_performed->All());
+
+      REQUIRE(sym_parent->GetCPU().state.tasks_performed->Get(0));
+      REQUIRE(sym_parent->GetCPU().state.tasks_performed->CountOnes() == 1);
+
+      REQUIRE(sym_baby->GetCPU().state.parent_tasks_performed->Get(0));
+      REQUIRE(sym_baby->GetCPU().state.parent_tasks_performed->CountOnes() == 1);
+    }
+
+    THEN("The symbiont child tracks any gains or loses in task completions") {
+      // in this second generation, we expect the symbiont to lose every task except for NOT
+      // since first-gen organisms are uniquely marked as having parents who complete every task
+      REQUIRE(sym_baby->GetCPU().state.task_change_lose[0] == 0);
+      REQUIRE(sym_baby->GetCPU().state.task_change_gain[0] == 0);
+      for (unsigned int i = 1; i < CPU_BITSET_LENGTH; i++) {
+        REQUIRE(sym_baby->GetCPU().state.task_change_lose[i] == 1);
+        REQUIRE(sym_baby->GetCPU().state.task_change_gain[i] == 0);
+      }
+    }
+
+    THEN("The symbiont child tracks how its tasks compare to its parent's partner's tasks") {
+      REQUIRE(sym_baby->GetCPU().state.task_toward_partner[0] == 0);
+      REQUIRE(sym_baby->GetCPU().state.task_from_partner[0] == 0);
+
+      for (unsigned int i = 1; i < CPU_BITSET_LENGTH; i++) {
+        REQUIRE(sym_baby->GetCPU().state.task_toward_partner[i] == 0);
+        REQUIRE(sym_baby->GetCPU().state.task_from_partner[i] == 1);
+      }
+    }
+    sym_baby.Delete();
+  }
 }

--- a/source/test/sgp_mode_test/StressHost.test.cc
+++ b/source/test/sgp_mode_test/StressHost.test.cc
@@ -60,3 +60,52 @@ TEST_CASE("Extinction event", "[sgp]") {
     }
   }
 }
+
+TEST_CASE("Stress hosts evolve", "[sgp]") {
+  emp::Random random(32);
+  SymConfigSGP config;
+  config.ORGANISM_TYPE(STRESS);
+  config.START_MOI(0);
+  config.EXTINCTION_FREQUENCY(100000);
+  config.GRID_X(10);
+  config.GRID_Y(100);
+  config.HOST_REPRO_RES(20);
+  size_t world_size = config.GRID_X() * config.GRID_Y();
+
+  SGPWorld world(random, &config, LogicTasks);
+  world.SetupHosts(&world_size);
+
+  REQUIRE(world.GetNumOrgs() == world_size);
+
+  size_t no_mut_NOT_rate = 600000;
+
+  size_t run_updates = 15000;
+
+  WHEN("Mutation size is 0") {
+    config.MUTATION_SIZE(0); //  chance
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Stress hosts do not accrue mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host == 0);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host == no_mut_NOT_rate);
+    }
+  }
+
+  WHEN("Mutation size is greater than 0") {
+    config.MUTATION_SIZE(0.0002);
+    for (size_t i = 0; i < run_updates; i++) {
+      world.Update();
+    }
+    THEN("Stress hosts accrue more mutations late in an experiment") {
+      REQUIRE(world.GetNumOrgs() == world_size);
+      auto it = world.GetTaskSet().begin();
+      ++it;
+      REQUIRE((*it).n_succeeds_host > 30);
+      REQUIRE((*world.GetTaskSet().begin()).n_succeeds_host > no_mut_NOT_rate * 2);
+    }
+  }
+}


### PR DESCRIPTION
Genome inheritance fix: SGPHost subclass constructors now send passed genomes on to the SGPHost constructor, permitting inheritance of genomes (and thus evolution). Tests check that an expected amount of NOT evolution can occur for both subclasses.

To-from parent/partner tracking: track gain/loss of tasks in infection bitstring over time.
Removed cycling disincentive
Track parent tasks performed: infect/defend based on what tasks a parent completed.