### PR TITLE
Fix coverage directories

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,5 @@ ignore:
   - "web" # the web code does not currently have a test framework
   - "source/Organism.h"
   - "source/*.test.cc"
+  - "Empirical"
+  - "coverage_source"


### PR DESCRIPTION
Currently coverage of Empirical is factored into our overall coverage. This should fix that.