### PR TITLE
Increasing transmission data node bin count

### DIFF
--- a/source/default_mode/DataNodes.h
+++ b/source/default_mode/DataNodes.h
@@ -366,48 +366,81 @@ emp::DataFile & SymWorld::SetUpTransmissionFile(const std::string & filename){
   auto & node2 = GetHorizontalTransmissionSuccessCount();
   auto & node3 = GetVerticalTransmissionAttemptCount();
   auto & node4 = GetVerticalTransmissionSuccessCount(); 
-  auto & node5 = GetHorizontalTransmissionTagFailCount();
-  auto & node6 = GetHorizontalTransmissionSizeFailCount();
-
+  
   file.AddVar(update, "update", "Update");
   //horizontal transmission
-  file.AddHistBin(node1, 0, "horiz_attempt_-1_-0.6", "Count for histogram bin for horizontal attempts with int val -1 to <-0.6");
-  file.AddHistBin(node1, 1, "horiz_attempt_-0.6_-0.2", "Count for histogram bin for horizontal attempts with int val -0.6 to <-0.2");
-  file.AddHistBin(node1, 2, "horiz_attempt_-0.2_0.2", "Count for histogram bin for horizontal attempts with int val -0.2 to <0.2");
-  file.AddHistBin(node1, 3, "horiz_attempt_0.2_0.6", "Count for histogram bin for horizontal attempts with int val 0.2 to <0.6");
-  file.AddHistBin(node1, 4, "horiz_attempt_0.6_1", "Count for histogram bin for horizontal attempts with int val 0.6 to 1", true);
+  file.AddHistBin(node1, 0, "horiz_attempt_-1_-0.8", "Count for histogram bin for horizontal attempts with int val -1 to <-0.8");
+  file.AddHistBin(node1, 1, "horiz_attempt_-0.8_-0.6", "Count for histogram bin for horizontal attempts with int val -0.8 to <-0.6");
+  file.AddHistBin(node1, 2, "horiz_attempt_-0.6_0.4", "Count for histogram bin for horizontal attempts with int val -0.6 to <-0.4");
+  file.AddHistBin(node1, 3, "horiz_attempt_-0.4_0.2", "Count for histogram bin for horizontal attempts with int val -0.4 to <-0.2");
+  file.AddHistBin(node1, 4, "horiz_attempt_-0.2_0", "Count for histogram bin for horizontal attempts with int val -0.2 to <0");
+  file.AddHistBin(node1, 5, "horiz_attempt_0_0.2", "Count for histogram bin for horizontal attempts with int val 0 to <-0.2");
+  file.AddHistBin(node1, 6, "horiz_attempt_0.2_0.4", "Count for histogram bin for horizontal attempts with int val 0.2 to <0.4");
+  file.AddHistBin(node1, 7, "horiz_attempt_0.4_0.6", "Count for histogram bin for horizontal attempts with int val 0.4 to <0.6");
+  file.AddHistBin(node1, 8, "horiz_attempt_0.6_0.8", "Count for histogram bin for horizontal attempts with int val 0.6 to <0.8");
+  file.AddHistBin(node1, 9, "horiz_attempt_0.8_1", "Count for histogram bin for horizontal attempts with int val 0.8 to 1", true);
 
-  file.AddHistBin(node2, 0, "horiz_success_-1_-0.6", "Count for histogram bin for horizontal successes with int val -1 to <-0.6");
-  file.AddHistBin(node2, 1, "horiz_success_-0.6_-0.2", "Count for histogram bin for horizontal successes with int val -0.6 to <-0.2");
-  file.AddHistBin(node2, 2, "horiz_success_-0.2_0.2", "Count for histogram bin for horizontal successes with int val -0.2 to <0.2");
-  file.AddHistBin(node2, 3, "horiz_success_0.2_0.6", "Count for histogram bin for horizontal successes with int val 0.2 to <0.6");
-  file.AddHistBin(node2, 4, "horiz_success_0.6_1", "Count for histogram bin for horizontal successes with int val 0.6 to 1", true);
+  file.AddHistBin(node2, 0, "horiz_success_-1_-0.8", "Count for histogram bin for horizontal successes with int val -1 to <-0.8");
+  file.AddHistBin(node2, 1, "horiz_success_-0.8_-0.6", "Count for histogram bin for horizontal successes with int val -0.8 to <-0.6");
+  file.AddHistBin(node2, 2, "horiz_success_-0.6_0.4", "Count for histogram bin for horizontal successes with int val -0.6 to <-0.4");
+  file.AddHistBin(node2, 3, "horiz_success_-0.4_0.2", "Count for histogram bin for horizontal successes with int val -0.4 to <-0.2");
+  file.AddHistBin(node2, 4, "horiz_success_-0.2_0", "Count for histogram bin for horizontal successes with int val -0.2 to <0");
+  file.AddHistBin(node2, 5, "horiz_success_0_0.2", "Count for histogram bin for horizontal successes with int val 0 to <-0.2");
+  file.AddHistBin(node2, 6, "horiz_success_0.2_0.4", "Count for histogram bin for horizontal successes with int val 0.2 to <0.4");
+  file.AddHistBin(node2, 7, "horiz_success_0.4_0.6", "Count for histogram bin for horizontal successes with int val 0.4 to <0.6");
+  file.AddHistBin(node2, 8, "horiz_success_0.6_0.8", "Count for histogram bin for horizontal successes with int val 0.6 to <0.8");
+  file.AddHistBin(node2, 9, "horiz_success_0.8_1", "Count for histogram bin for horizontal successes with int val 0.8 to 1", true);
 
   //vertical transmission
-  file.AddHistBin(node3, 0, "vert_attempt_-1_-0.6", "Count for histogram bin for vertical attempts with int val -1 to <-0.6");
-  file.AddHistBin(node3, 1, "vert_attempt_-0.6_-0.2", "Count for histogram bin for vertical attempts with int val -0.6 to <-0.2");
-  file.AddHistBin(node3, 2, "vert_attempt_-0.2_0.2", "Count for histogram bin for vertical attempts with int val -0.2 to <0.2");
-  file.AddHistBin(node3, 3, "vert_attempt_0.2_0.6", "Count for histogram bin for vertical attempts with int val 0.2 to <0.6");
-  file.AddHistBin(node3, 4, "vert_attempt_0.6_1", "Count for histogram bin for vertical attempts with int val 0.6 to 1", true);
+  file.AddHistBin(node3, 0, "vert_attempt_-1_-0.8", "Count for histogram bin for vertical attempts with int val -1 to <-0.8");
+  file.AddHistBin(node3, 1, "vert_attempt_-0.8_-0.6", "Count for histogram bin for vertical attempts with int val -0.8 to <-0.6");
+  file.AddHistBin(node3, 2, "vert_attempt_-0.6_0.4", "Count for histogram bin for vertical attempts with int val -0.6 to <-0.4");
+  file.AddHistBin(node3, 3, "vert_attempt_-0.4_0.2", "Count for histogram bin for vertical attempts with int val -0.4 to <-0.2");
+  file.AddHistBin(node3, 4, "vert_attempt_-0.2_0", "Count for histogram bin for vertical attempts with int val -0.2 to <0");
+  file.AddHistBin(node3, 5, "vert_attempt_0_0.2", "Count for histogram bin for vertical attempts with int val 0 to <-0.2");
+  file.AddHistBin(node3, 6, "vert_attempt_0.2_0.4", "Count for histogram bin for vertical attempts with int val 0.2 to <0.4");
+  file.AddHistBin(node3, 7, "vert_attempt_0.4_0.6", "Count for histogram bin for vertical attempts with int val 0.4 to <0.6");
+  file.AddHistBin(node3, 8, "vert_attempt_0.6_0.8", "Count for histogram bin for vertical attempts with int val 0.6 to <0.8");
+  file.AddHistBin(node3, 9, "vert_attempt_0.8_1", "Count for histogram bin for vertical attempts with int val 0.8 to 1", true);
 
-  file.AddHistBin(node4, 0, "vert_success_-1_-0.6", "Count for histogram bin for vertical successes with int val -1 to <-0.6");
-  file.AddHistBin(node4, 1, "vert_success_-0.6_-0.2", "Count for histogram bin for vertical successes with int val -0.6 to <-0.2");
-  file.AddHistBin(node4, 2, "vert_success_-0.2_0.2", "Count for histogram bin for vertical successes with int val -0.2 to <0.2");
-  file.AddHistBin(node4, 3, "vert_success_0.2_0.6", "Count for histogram bin for vertical successes with int val 0.2 to <0.6");
-  file.AddHistBin(node4, 4, "vert_success_0.6_1", "Count for histogram bin for vertical successes with int val 0.6 to 1", true);
+  file.AddHistBin(node4, 0, "vert_success_-1_-0.8", "Count for histogram bin for vertical successes with int val -1 to <-0.8");
+  file.AddHistBin(node4, 1, "vert_success_-0.8_-0.6", "Count for histogram bin for vertical successes with int val -0.8 to <-0.6");
+  file.AddHistBin(node4, 2, "vert_success_-0.6_0.4", "Count for histogram bin for vertical successes with int val -0.6 to <-0.4");
+  file.AddHistBin(node4, 3, "vert_success_-0.4_0.2", "Count for histogram bin for vertical successes with int val -0.4 to <-0.2");
+  file.AddHistBin(node4, 4, "vert_success_-0.2_0", "Count for histogram bin for vertical successes with int val -0.2 to <0");
+  file.AddHistBin(node4, 5, "vert_success_0_0.2", "Count for histogram bin for vertical successes with int val 0 to <-0.2");
+  file.AddHistBin(node4, 6, "vert_success_0.2_0.4", "Count for histogram bin for vertical successes with int val 0.2 to <0.4");
+  file.AddHistBin(node4, 7, "vert_success_0.4_0.6", "Count for histogram bin for vertical successes with int val 0.4 to <0.6");
+  file.AddHistBin(node4, 8, "vert_success_0.6_0.8", "Count for histogram bin for vertical successes with int val 0.6 to <0.8");
+  file.AddHistBin(node4, 9, "vert_success_0.8_1", "Count for histogram bin for vertical successes with int val 0.8 to 1", true);
 
-  // horiz failure 
-  file.AddHistBin(node5, 0, "horiz_tagfail_-1_-0.6", "Count for histogram bin for horizontal tag failure with int val -1 to <-0.6");
-  file.AddHistBin(node5, 1, "horiz_tagfail_-0.6_-0.2", "Count for histogram bin for horizontal tag failure with int val -0.6 to <-0.2");
-  file.AddHistBin(node5, 2, "horiz_tagfail_-0.2_0.2", "Count for histogram bin for horizontal tag failure with int val -0.2 to <0.2");
-  file.AddHistBin(node5, 3, "horiz_tagfail_0.2_0.6", "Count for histogram bin for horizontal tag failure with int val 0.2 to <0.6");
-  file.AddHistBin(node5, 4, "horiz_tagfail_0.6_1", "Count for histogram bin for horizontal tag failure with int val 0.6 to 1", true);
+  // horiz failure, only relevant if tag matching is on
+  if (my_config->TAG_MATCHING()) {
+    auto& node5 = GetHorizontalTransmissionTagFailCount();
+    auto& node6 = GetHorizontalTransmissionSizeFailCount();
 
-  file.AddHistBin(node6, 0, "horiz_sizefail_-1_-0.6", "Count for histogram bin for horizontal size failure with int val -1 to <-0.6");
-  file.AddHistBin(node6, 1, "horiz_sizefail_-0.6_-0.2", "Count for histogram bin for horizontal size failure with int val -0.6 to <-0.2");
-  file.AddHistBin(node6, 2, "horiz_sizefail_-0.2_0.2", "Count for histogram bin for horizontal size failure with int val -0.2 to <0.2");
-  file.AddHistBin(node6, 3, "horiz_sizefail_0.2_0.6", "Count for histogram bin for horizontal size failure with int val 0.2 to <0.6");
-  file.AddHistBin(node6, 4, "horiz_sizefail_0.6_1", "Count for histogram bin for horizontal size failure with int val 0.6 to 1", true);
+    file.AddHistBin(node5, 0, "horiz_tagfail_-1_-0.8", "Count for histogram bin for horizontal tag failures with int val -1 to <-0.8");
+    file.AddHistBin(node5, 1, "horiz_tagfail_-0.8_-0.6", "Count for histogram bin for horizontal tag failures with int val -0.8 to <-0.6");
+    file.AddHistBin(node5, 2, "horiz_tagfail_-0.6_0.4", "Count for histogram bin for horizontal tag failures with int val -0.6 to <-0.4");
+    file.AddHistBin(node5, 3, "horiz_tagfail_-0.4_0.2", "Count for histogram bin for horizontal tag failures with int val -0.4 to <-0.2");
+    file.AddHistBin(node5, 4, "horiz_tagfail_-0.2_0", "Count for histogram bin for horizontal tag failures with int val -0.2 to <0");
+    file.AddHistBin(node5, 5, "horiz_tagfail_0_0.2", "Count for histogram bin for horizontal tag failures with int val 0 to <-0.2");
+    file.AddHistBin(node5, 6, "horiz_tagfail_0.2_0.4", "Count for histogram bin for horizontal tag failures with int val 0.2 to <0.4");
+    file.AddHistBin(node5, 7, "horiz_tagfail_0.4_0.6", "Count for histogram bin for horizontal tag failures with int val 0.4 to <0.6");
+    file.AddHistBin(node5, 8, "horiz_tagfail_0.6_0.8", "Count for histogram bin for horizontal tag failures with int val 0.6 to <0.8");
+    file.AddHistBin(node5, 9, "horiz_tagfail_0.8_1", "Count for histogram bin for horizontal tag failures with int val 0.8 to 1", true);
+
+    file.AddHistBin(node6, 0, "horiz_sizefail_-1_-0.8", "Count for histogram bin for horizontal size failures with int val -1 to <-0.8");
+    file.AddHistBin(node6, 1, "horiz_sizefail_-0.8_-0.6", "Count for histogram bin for horizontal size failures with int val -0.8 to <-0.6");
+    file.AddHistBin(node6, 2, "horiz_sizefail_-0.6_0.4", "Count for histogram bin for horizontal size failures with int val -0.6 to <-0.4");
+    file.AddHistBin(node6, 3, "horiz_sizefail_-0.4_0.2", "Count for histogram bin for horizontal size failures with int val -0.4 to <-0.2");
+    file.AddHistBin(node6, 4, "horiz_sizefail_-0.2_0", "Count for histogram bin for horizontal size failures with int val -0.2 to <0");
+    file.AddHistBin(node6, 5, "horiz_sizefail_0_0.2", "Count for histogram bin for horizontal size failures with int val 0 to <-0.2");
+    file.AddHistBin(node6, 6, "horiz_sizefail_0.2_0.4", "Count for histogram bin for horizontal size failures with int val 0.2 to <0.4");
+    file.AddHistBin(node6, 7, "horiz_sizefail_0.4_0.6", "Count for histogram bin for horizontal size failures with int val 0.4 to <0.6");
+    file.AddHistBin(node6, 8, "horiz_sizefail_0.6_0.8", "Count for histogram bin for horizontal size failures with int val 0.6 to <0.8");
+    file.AddHistBin(node6, 9, "horiz_sizefail_0.8_1", "Count for histogram bin for horizontal size failures with int val 0.8 to 1", true);
+  }
 
   file.PrintHeaderKeys();
 
@@ -940,7 +973,7 @@ emp::DataMonitor<double,emp::data::Histogram>& SymWorld::GetHostedSymInfectChanc
 emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmissionAttemptCount() {
   if (!data_node_attempts_horiztrans) {
     data_node_attempts_horiztrans.New();
-    data_node_attempts_horiztrans->SetupBins(-1.0, 1.4, 6);
+    data_node_attempts_horiztrans->SetupBins(-1.0, 1.2, 11);
   }
   
   return *data_node_attempts_horiztrans;
@@ -958,7 +991,7 @@ emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmiss
 emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmissionTagFailCount() {
   if (!data_node_tagfail_horiztrans) {
     data_node_tagfail_horiztrans.New();
-    data_node_tagfail_horiztrans->SetupBins(-1.0, 1.4, 6);
+    data_node_tagfail_horiztrans->SetupBins(-1.0, 1.2, 11);
   }
 
   return *data_node_tagfail_horiztrans;
@@ -976,7 +1009,7 @@ emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmiss
 emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmissionSizeFailCount() {
   if (!data_node_sizefail_horiztrans) {
     data_node_sizefail_horiztrans.New();
-    data_node_sizefail_horiztrans->SetupBins(-1.0, 1.4, 6);
+    data_node_sizefail_horiztrans->SetupBins(-1.0, 1.2, 11);
   }
 
   return *data_node_sizefail_horiztrans;
@@ -996,7 +1029,7 @@ emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmiss
 emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmissionSuccessCount() {
   if (!data_node_successes_horiztrans) {
     data_node_successes_horiztrans.New();
-    data_node_successes_horiztrans->SetupBins(-1.0, 1.4, 6);
+    data_node_successes_horiztrans->SetupBins(-1.0, 1.2, 11);
   }
   
   return *data_node_successes_horiztrans;
@@ -1015,7 +1048,7 @@ emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetHorizontalTransmiss
 emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetVerticalTransmissionAttemptCount() {
   if (!data_node_attempts_verttrans) {
     data_node_attempts_verttrans.New();
-    data_node_attempts_verttrans->SetupBins(-1.0, 1.4, 6);
+    data_node_attempts_verttrans->SetupBins(-1.0, 1.2, 11);
   }
   return *data_node_attempts_verttrans;
 }
@@ -1033,7 +1066,7 @@ emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetVerticalTransmissio
 emp::DataMonitor<double, emp::data::Histogram>& SymWorld::GetVerticalTransmissionSuccessCount() {
   if (!data_node_successes_verttrans) {
     data_node_successes_verttrans.New();
-    data_node_successes_verttrans->SetupBins(-1.0, 1.4, 6);
+    data_node_successes_verttrans->SetupBins(-1.0, 1.2, 11);
   }
   
   return *data_node_successes_verttrans;

--- a/source/test/default_mode_test/DataNodes.test.cc
+++ b/source/test/default_mode_test/DataNodes.test.cc
@@ -587,7 +587,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
   GIVEN( "a world" ) {
     emp::Random random(17);
     SymConfigBase config;
-    int int_val = 0;
+    double int_val = 1;
     SymWorld world(random, &config);
     size_t world_size = 4;
     world.Resize(world_size);
@@ -596,6 +596,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
     emp::DataMonitor<double, emp::data::Histogram>& data_node_attempts_horiztrans = world.GetHorizontalTransmissionAttemptCount();
     emp::WorldPosition parent_pos = emp::WorldPosition(0, 0);
     REQUIRE(data_node_attempts_horiztrans.GetCount() == 0);
+    REQUIRE(data_node_attempts_horiztrans.GetHistCounts()[9] == 0);
 
     WHEN("Free living symbionts are allowed"){
       config.FREE_LIVING_SYMS(1);
@@ -608,6 +609,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
 
         THEN("The count of attempted horizontal transmissions increments"){
           REQUIRE(data_node_attempts_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_horiztrans.GetHistCounts()[9] == 1);
         }
       }
         WHEN("There are no valid cells to transmit into and the symbiont dies trying to transmit"){
@@ -616,6 +618,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
         REQUIRE(world.GetNumOrgs() == 1);
         THEN("The count of attempted horizontal transmissions increments"){
           REQUIRE(data_node_attempts_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_horiztrans.GetHistCounts()[9] == 1);
         }
         symbiont.Delete(); // won't be caught by symworld destructor due to resize
       }
@@ -631,6 +634,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
         REQUIRE(host->HasSym() == true);
         THEN("The count of attempted horizontal transmissions increments"){
           REQUIRE(data_node_attempts_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_horiztrans.GetHistCounts()[9] == 1);
         }
       }
       WHEN("A symbiont dies trying to horizontally transmit into a host"){
@@ -643,6 +647,7 @@ TEST_CASE("GetHorizontalTransmissionAttemptCount", "[default]"){
         REQUIRE(host->GetSymbionts().at(0) == parent_symbiont);
         THEN("The count of attempted horizontal transmissions increments"){
           REQUIRE(data_node_attempts_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_horiztrans.GetHistCounts()[9] == 1);
         }
       }
       symbiont.Delete();
@@ -655,7 +660,7 @@ TEST_CASE("GetHorizontalTransmissionTagFailCount", "[default]") {
   GIVEN("a world") {
     emp::Random random(17);
     SymConfigBase config;
-    int int_val = 0;
+    double int_val = 1;
     SymWorld world(random, &config);
     size_t world_size = 4;
     world.Resize(world_size);
@@ -674,6 +679,7 @@ TEST_CASE("GetHorizontalTransmissionTagFailCount", "[default]") {
       REQUIRE(host->HasSym() == true);
       THEN("The tag failure count is NOT incremented") {
         REQUIRE(data_node_tagfail_horiztrans.GetCount() == 0);
+        REQUIRE(data_node_tagfail_horiztrans.GetHistCounts()[9] == 0);
       }
       symbiont.Delete();
     }
@@ -699,6 +705,7 @@ TEST_CASE("GetHorizontalTransmissionTagFailCount", "[default]") {
         REQUIRE(target_host->HasSym() == false);
         THEN("The tag failure count is incremented") {
           REQUIRE(data_node_tagfail_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_tagfail_horiztrans.GetHistCounts()[9] == 1);
         }
       }
       WHEN("The failure is only due to size") {
@@ -710,6 +717,7 @@ TEST_CASE("GetHorizontalTransmissionTagFailCount", "[default]") {
         REQUIRE(target_host->GetSymbionts().at(0) == filler_symbiont);
         THEN("The tag failure count is NOT incremented") {
           REQUIRE(data_node_tagfail_horiztrans.GetCount() == 0);
+          REQUIRE(data_node_tagfail_horiztrans.GetHistCounts()[9] == 0);
         }
       }
       WHEN("The failure is due to size and tag mismatch") {
@@ -721,6 +729,7 @@ TEST_CASE("GetHorizontalTransmissionTagFailCount", "[default]") {
         REQUIRE(target_host->GetSymbionts().at(0) == filler_symbiont);
         THEN("The tag failure count is NOT incremented") {
           REQUIRE(data_node_tagfail_horiztrans.GetCount() == 0);
+          REQUIRE(data_node_tagfail_horiztrans.GetHistCounts()[9] == 0);
         }
       }
     }
@@ -731,7 +740,7 @@ TEST_CASE("GetHorizontalTransmissionSizeFailCount", "[default]") {
   GIVEN("a world") {
     emp::Random random(17);
     SymConfigBase config;
-    int int_val = 0;
+    double int_val = 1;
     SymWorld world(random, &config);
     size_t world_size = 4;
     world.Resize(world_size);
@@ -750,6 +759,7 @@ TEST_CASE("GetHorizontalTransmissionSizeFailCount", "[default]") {
       REQUIRE(host->HasSym() == true);
       THEN("The tag failure count is NOT incremented") {
         REQUIRE(data_node_sizefail_horiztrans.GetCount() == 0);
+        REQUIRE(data_node_sizefail_horiztrans.GetHistCounts()[9] == 0);
       }
       symbiont.Delete();
     }
@@ -775,6 +785,7 @@ TEST_CASE("GetHorizontalTransmissionSizeFailCount", "[default]") {
         REQUIRE(target_host->HasSym() == false);
         THEN("The size failure count is NOT incremented") {
           REQUIRE(data_node_sizefail_horiztrans.GetCount() == 0);
+          REQUIRE(data_node_sizefail_horiztrans.GetHistCounts()[9] == 0);
         }
       }
       WHEN("The failure is only due to size") {
@@ -786,6 +797,7 @@ TEST_CASE("GetHorizontalTransmissionSizeFailCount", "[default]") {
         REQUIRE(target_host->GetSymbionts().at(0) == filler_symbiont);
         THEN("The size failure count is incremented") {
           REQUIRE(data_node_sizefail_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_sizefail_horiztrans.GetHistCounts()[9] == 1);
         }
       }
       WHEN("The failure is due to size and tag mismatch") {
@@ -797,6 +809,7 @@ TEST_CASE("GetHorizontalTransmissionSizeFailCount", "[default]") {
         REQUIRE(target_host->GetSymbionts().at(0) == filler_symbiont);
         THEN("The size failure count is NOT incremented") {
           REQUIRE(data_node_sizefail_horiztrans.GetCount() == 0);
+          REQUIRE(data_node_sizefail_horiztrans.GetHistCounts()[9] == 0);
         }
       }
     }
@@ -807,7 +820,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
   GIVEN( "a world" ) {
     emp::Random random(17);
     SymConfigBase config;
-    int int_val = 0;
+    double int_val = 1;
     SymWorld world(random, &config);
     size_t world_size = 4;
     world.Resize(world_size);
@@ -828,6 +841,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
 
         THEN("The count of successful horizontal transmissions increments"){
           REQUIRE(data_node_successes_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_successes_horiztrans.GetHistCounts()[9] == 1);
         }
       }
       WHEN("There are no valid cells to transmit into and the symbiont dies trying to transmit"){
@@ -836,6 +850,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
         REQUIRE(world.GetNumOrgs() == 1);
         THEN("The count of successful horizontal transmissions does not change"){
           REQUIRE(data_node_successes_horiztrans.GetCount() == 0);
+          REQUIRE(data_node_successes_horiztrans.GetHistCounts()[9] == 0);
         }
         symbiont.Delete(); // won't be caught by symworld destructor due to resize 
       }
@@ -851,6 +866,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
         REQUIRE(host->HasSym() == true);
         THEN("The count of successful horizontal transmissions increments"){
           REQUIRE(data_node_successes_horiztrans.GetCount() == 1);
+          REQUIRE(data_node_successes_horiztrans.GetHistCounts()[9] == 1);
         }
       }
       WHEN("A symbiont dies trying to horizontally transmit into a host"){
@@ -863,6 +879,7 @@ TEST_CASE("GetHorizontalTransmissionSuccessCount", "[default]"){
         REQUIRE(host->GetSymbionts().at(0) == parent_symbiont);
         THEN("The count of successful horizontal transmissions does not change") {
           REQUIRE(data_node_successes_horiztrans.GetCount() == 0);
+          REQUIRE(data_node_successes_horiztrans.GetHistCounts()[9] == 0);
         }
       }
       symbiont.Delete();
@@ -890,11 +907,32 @@ TEST_CASE("GetVerticalTransmissionAttemptCount", "[default]"){
       emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(&random, &world, &config, int_val);
       emp::Ptr<Host> host_baby = emp::NewPtr<Host>(&random, &world, &config, int_val);
 
-      symbiont->VerticalTransmission(host_baby);
-
-      THEN("The count of attempted vertical transmissions increments"){
-        REQUIRE(host_baby->HasSym() == true);
-        REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+      WHEN("The symbiont's parent has a very high interaction value") {
+        symbiont->SetIntVal(1.0);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == true);
+          REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_verttrans.GetHistCounts()[9] == 1);
+        }
+      }
+      WHEN("The symbiont's parent has a middling interaction value") {
+        symbiont->SetIntVal(-0.2);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == true);
+          REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_verttrans.GetHistCounts()[4] == 1);
+        }
+      }
+      WHEN("The symbiont's parent has a very low interaction value") {
+        symbiont->SetIntVal(-1);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == true);
+          REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_verttrans.GetHistCounts()[0] == 1);
+        }
       }
 
       symbiont.Delete();
@@ -910,11 +948,32 @@ TEST_CASE("GetVerticalTransmissionAttemptCount", "[default]"){
       symbiont->SetTag(sym_bit_set);
       host_baby->SetTag(host_bit_set);
 
-      symbiont->VerticalTransmission(host_baby);
-
-      THEN("The count of attempted vertical transmissions increments") {
-        REQUIRE(host_baby->HasSym() == false);
-        REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+      WHEN("The symbiont's parent has a very high interaction value") {
+        symbiont->SetIntVal(1.0);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == false);
+          REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_verttrans.GetHistCounts()[9] == 1);
+        }
+      }
+      WHEN("The symbiont's parent has a middling interaction value") {
+        symbiont->SetIntVal(-0.2);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == false);
+          REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_verttrans.GetHistCounts()[4] == 1);
+        }
+      }
+      WHEN("The symbiont's parent has a very low interaction value") {
+        symbiont->SetIntVal(-1);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == false);
+          REQUIRE(data_node_attempts_verttrans.GetCount() == 1);
+          REQUIRE(data_node_attempts_verttrans.GetHistCounts()[0] == 1);
+        }
       }
       
       symbiont.Delete();
@@ -927,7 +986,7 @@ TEST_CASE("GetVerticalTransmissionSuccessCount", "[default]") {
   GIVEN("a world") {
     emp::Random random(17);
     SymConfigBase config;
-    int int_val = 0;
+    double int_val = 1;
     config.TAG_MATCHING(1);
     SymWorld world(random, &config);
     size_t world_size = 4;
@@ -941,19 +1000,40 @@ TEST_CASE("GetVerticalTransmissionSuccessCount", "[default]") {
     WHEN("A symbiont baby gets vertically transmitted into a host baby") {
       emp::Ptr<Symbiont> symbiont = emp::NewPtr<Symbiont>(&random, &world, &config, int_val);
       emp::Ptr<Host> host_baby = emp::NewPtr<Host>(&random, &world, &config, int_val);
-      
+
       emp::BitSet<TAG_LENGTH> sym_bit_set = emp::BitSet<TAG_LENGTH>();
       emp::BitSet<TAG_LENGTH> host_bit_set = emp::BitSet<TAG_LENGTH>();
       symbiont->SetTag(sym_bit_set);
       host_baby->SetTag(host_bit_set);
 
-      symbiont->VerticalTransmission(host_baby);
-
-      THEN("The count of successful vertical transmissions increments") {
-        REQUIRE(host_baby->HasSym() == true);
-        REQUIRE(data_node_successes_verttrans.GetCount() == 1);
+      WHEN("The symbiont's parent has a very high interaction value"){
+        symbiont->SetIntVal(1.0);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == true);
+          REQUIRE(data_node_successes_verttrans.GetCount() == 1);
+          REQUIRE(data_node_successes_verttrans.GetHistCounts()[9]);
+        }
       }
-
+      WHEN("The symbiont's parent has a middling interaction value"){
+        symbiont->SetIntVal(-0.2);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == true);
+          REQUIRE(data_node_successes_verttrans.GetCount() == 1);
+          REQUIRE(data_node_successes_verttrans.GetHistCounts()[4] == 1);
+        }
+      }
+      WHEN("The symbiont's parent has a very low interaction value"){
+        symbiont->SetIntVal(-1);
+        symbiont->VerticalTransmission(host_baby);
+        THEN("The count of successful vertical transmissions increments and the correct histogram bin is incremented") {
+          REQUIRE(host_baby->HasSym() == true);
+          REQUIRE(data_node_successes_verttrans.GetCount() == 1);
+          REQUIRE(data_node_successes_verttrans.GetHistCounts()[0] == 1);
+        }
+      }
+      
       symbiont.Delete();
       host_baby.Delete();
     }
@@ -968,7 +1048,7 @@ TEST_CASE("GetVerticalTransmissionSuccessCount", "[default]") {
 
       symbiont->VerticalTransmission(host_baby);
 
-      THEN("The count of successful vertical transmissions increments") {
+      THEN("The count of successful vertical transmissions does not increment") {
         REQUIRE(host_baby->HasSym() == false);
         REQUIRE(data_node_successes_verttrans.GetCount() == 0);
       }


### PR DESCRIPTION
Updating transmission histograms to have 10 (instead of 5) bins, capturing interaction value 1.0 in the top bin. 