### PR TITLE
Added Steal and Donate Health host with config

### DIFF
--- a/source/Organism.h
+++ b/source/Organism.h
@@ -75,6 +75,7 @@ class Organism {
     std::cout << "MakeNew called from Organism" << std::endl;
     throw "Organism method called!";
   }
+  
 
   //Symbiont functions
 
@@ -176,6 +177,14 @@ class Organism {
   virtual void ClearReproSyms() {
     std::cout << "ClearReproSyms called from Organism" << std::endl;
     throw "Organism method called!";}
+  virtual void CycleTransfer(int _in){
+    std::cout << "CycleTransfer called from Organism" << std::endl;
+    throw "Organism method called!";
+  }
+  virtual int GetCyclesGiven(){
+    std::cout << "GetCyclesGiven called from Organism" << std::endl;
+    throw "Organism method called!";
+  }
 
   //Bacterium functions
   virtual double ProcessLysogenResources(double phage_inc_val){

--- a/source/catch/main.cc
+++ b/source/catch/main.cc
@@ -34,11 +34,7 @@
 #include "../test/sgp_mode_test/SGPHost.test.cc"
 #include "../test/sgp_mode_test/SGPSymbiont.test.cc"
 #include "../test/sgp_mode_test/StressHost.test.cc"
-//#include "../test/sgp_mode_test/FirstCredit.test.cc"
-#include "../test/sgp_mode_test/OnlyNOT.test.cc"
-//#include "../test/sgp_mode_test/ParentTask.test.cc"
-//#include "../test/sgp_mode_test/DonateSteal.test.cc"
-//#include "../test/sgp_mode_test/HealthHost.test.cc"
+#include "../test/sgp_mode_test/HealthHost.test.cc"
 
 #include "../test/integration_test/spatial_structure/vt.test.cc"
 #include "../test/integration_test/lysogeny/plr.test.cc"

--- a/source/catch/main.cc
+++ b/source/catch/main.cc
@@ -34,9 +34,10 @@
 #include "../test/sgp_mode_test/SGPHost.test.cc"
 #include "../test/sgp_mode_test/SGPSymbiont.test.cc"
 #include "../test/sgp_mode_test/StressHost.test.cc"
-#include "../test/sgp_mode_test/FirstCredit.test.cc"
+//#include "../test/sgp_mode_test/FirstCredit.test.cc"
 #include "../test/sgp_mode_test/OnlyNOT.test.cc"
-#include "../test/sgp_mode_test/ParentTask.test.cc"
+//#include "../test/sgp_mode_test/ParentTask.test.cc"
+//#include "../test/sgp_mode_test/DonateSteal.test.cc"
 //#include "../test/sgp_mode_test/HealthHost.test.cc"
 
 #include "../test/integration_test/spatial_structure/vt.test.cc"

--- a/source/sgp_mode/GenomeLibrary.h
+++ b/source/sgp_mode/GenomeLibrary.h
@@ -340,8 +340,19 @@ sgpl::Program<Spec> CreateStartProgram(emp::Ptr<SymConfigSGP> config) {
   if (config->RANDOM_ANCESTOR()) {
     return CreateRandomProgram(PROGRAM_LENGTH);
   } else if (config->TASK_TYPE() == 1) {
-  
-    return CreateParasiteNotProgram(PROGRAM_LENGTH);
+    if(config->DONATION_STEAL_INST() == 1){
+      if(config->STRESS_TYPE() == 1){
+         std::cout << "eyyy its parasite time" << std::endl;
+        return CreateParasiteNotProgram(PROGRAM_LENGTH);
+      }
+      else if(config->STRESS_TYPE() == 0){
+        return CreateMutualistNotProgram(PROGRAM_LENGTH);
+      }
+    }
+    else{
+      std::cout << "U said I cant steal.." << std::endl;
+      return CreateNotProgram(PROGRAM_LENGTH);
+    }
   } else {
     return CreateReproProgram(PROGRAM_LENGTH);
   }

--- a/source/sgp_mode/GenomeLibrary.h
+++ b/source/sgp_mode/GenomeLibrary.h
@@ -30,8 +30,9 @@ using Library = sgpl::OpLibrary<
     //inst::Infect,
     // if-label doesn't make sense for SGP, same with *-head
     // and set-flow but this is required
-    sgpl::global::Anchor 
-    //inst::Steal
+    sgpl::global::Anchor,
+    inst::Steal,
+    inst::Donate
     >;
 
 using Spec = sgpl::Spec<Library, CPUState>;
@@ -263,6 +264,16 @@ public:
     Add("Nand", 0, 0, 0);
     Add("SharedIO");
   }
+
+  void AddSteal(){
+    
+    Add("Steal");
+    //std::cout << "Adding Steal" << std::endl;
+  }
+
+  void AddDonate(){
+    Add("Donate");
+  }
 };
 
 sgpl::Program<Spec> CreateRandomProgram(size_t length) {
@@ -277,6 +288,27 @@ sgpl::Program<Spec> CreateReproProgram(size_t length) {
 sgpl::Program<Spec> CreateNotProgram(size_t length) {
   ProgramBuilder program;
   program.AddNot();
+  return program.Build(length);
+}
+
+sgpl::Program<Spec> CreateParasiteNotProgram(size_t length) {
+  ProgramBuilder program;
+  program.AddSteal();
+  program.AddNot();
+  
+  return program.Build(length);
+}
+
+sgpl::Program<Spec> CreateMutualistNotProgram(size_t length) {
+  ProgramBuilder program;
+  program.AddNot();
+  program.AddDonate();
+  return program.Build(length);
+}
+
+sgpl::Program<Spec> CreateEquProgram(size_t length) {
+  ProgramBuilder program;
+  program.AddEqu();
   return program.Build(length);
 }
 
@@ -308,7 +340,8 @@ sgpl::Program<Spec> CreateStartProgram(emp::Ptr<SymConfigSGP> config) {
   if (config->RANDOM_ANCESTOR()) {
     return CreateRandomProgram(PROGRAM_LENGTH);
   } else if (config->TASK_TYPE() == 1) {
-    return CreateNotProgram(PROGRAM_LENGTH);
+  
+    return CreateParasiteNotProgram(PROGRAM_LENGTH);
   } else {
     return CreateReproProgram(PROGRAM_LENGTH);
   }

--- a/source/sgp_mode/HealthHost.h
+++ b/source/sgp_mode/HealthHost.h
@@ -7,6 +7,8 @@ class HealthHost : public SGPHost {
 
     public:
 
+    int cycles_given = 0;
+
       /**
    * Constructs a new SGPHost as an ancestor organism, with either a random
    * genome or a blank genome that knows how to do a simple task depending on
@@ -62,9 +64,26 @@ class HealthHost : public SGPHost {
         int host_cycle = 1;
         int sym_cycle = 0;
         if (HasSym()) {
-          if (sgp_config->STRESS_TYPE() == MUTUALIST) {
+          
+          if(sgp_config->DONATION_STEAL_INST()){
+            sym_cycle = 1;
+
+            if(cycles_given >= int(sgp_config->CYCLES_PER_UPDATE())){
+              host_cycle += 1;
+              sym_cycle -= 1;
+              cycles_given -= int(sgp_config->CYCLES_PER_UPDATE());
+              
+            }
+            else if(cycles_given <= (-1 * int(sgp_config->CYCLES_PER_UPDATE()))){
+              host_cycle -= 1;
+              sym_cycle += 1;
+              cycles_given += int(sgp_config->CYCLES_PER_UPDATE());
+
+            }
+          }
+          else{
+            if (sgp_config->STRESS_TYPE() == MUTUALIST) {
             //Host with mutualist gains 50% of CPU from mutualist
-    
             if (random->P(sgp_config->CPU_TRANSFER_CHANCE())) {
               host_cycle = 2;
               sym_cycle = 0;
@@ -82,6 +101,7 @@ class HealthHost : public SGPHost {
               host_cycle = 1;
               sym_cycle = 0;
             }
+          }
           }
         }
         
@@ -116,5 +136,15 @@ class HealthHost : public SGPHost {
       }
       GrowOlder();
     }
+
+    void CycleTransfer(int amount) override {
+      cycles_given += amount; 
+    }
+
+    int GetCyclesGiven(){
+      return cycles_given;
+    }
 };
+
+  
 #endif // HEALTHHOST_H

--- a/source/sgp_mode/Instructions.h
+++ b/source/sgp_mode/Instructions.h
@@ -138,58 +138,35 @@ INST(SharedIO, {
   state.input_buf.push(next);
 });
 INST(Donate, {
-  if (state.world->GetConfig()->DONATION_STEAL_INST()) {
-    if (state.organism->IsHost() || state.organism->GetHost() == nullptr)
+  if (state.world->GetConfig()->DONATION_STEAL_INST() && (state.world->GetConfig()->STRESS_TYPE() == 0 || state.world->GetConfig()->ALLOW_TRANSITION_EVOLUTION() == 1)) {
+    if (state.organism->IsHost() || state.organism->GetHost() == nullptr){
+
       return;
+    }
     if (emp::Ptr<Organism> host = state.organism->GetHost()) {
-      //Original Donate implementation:
-      // Donate 20% of the total points of the symbiont-host system
-      // This way, a sym can donate e.g. 40 or 60 percent of their points in a
-      // couple of instructions
-      // double to_donate =
-      //     fmin(state.organism->GetPoints(),
-      //          (state.organism->GetPoints() + host->GetPoints()) * 0.20);
-      // state.world->GetSymDonatedDataNode().WithMonitor(
-      //     [=](auto &m) { m.AddDatum(to_donate); });
-      // host->AddPoints(to_donate *
-      //                 (1.0 - state.world->GetConfig()->DONATE_PENALTY()));
-      // state.organism->AddPoints(-to_donate);
-
-
-
+  
       //New Donate implementation:
-      //emp::Ptr<HealthHost> health_host = host.DynamicCast<HealthHost>();
       host->CycleTransfer(int(state.world->GetConfig()->CYCLES_PER_UPDATE()));
-     // std::cout << "Im making good things happen" << std::endl;
+
 
     }
   }
+  else{
+  }
 });
 INST(Steal, {
-  if (state.world->GetConfig()->DONATION_STEAL_INST()) {
-    if (state.organism->IsHost() || state.organism->GetHost() == nullptr)
+  if (state.world->GetConfig()->DONATION_STEAL_INST() && (state.world->GetConfig()->STRESS_TYPE() == 1 || state.world->GetConfig()->ALLOW_TRANSITION_EVOLUTION() == 1)) {
+    if (state.organism->IsHost() || state.organism->GetHost() == nullptr){
       return;
+    }
     if (emp::Ptr<Organism> host = state.organism->GetHost()) {
-      //Original Steal Implementation:
-      // Steal 20% of the total points of the symbiont-host system
-      // This way, a sym can steal e.g. 40 or 60 percent of the host's points in
-      // a couple of instructions
-      // double to_steal =
-      //     fmin(host->GetPoints(),
-      //          (state.organism->GetPoints() + host->GetPoints()) * 0.20);
-      // state.world->GetSymStolenDataNode().WithMonitor(
-      //     [=](auto &m) { m.AddDatum(to_steal); });
-      // host->AddPoints(-to_steal);
-      // // 10% of the stolen resources are lost
-      // state.organism->AddPoints(
-      //     to_steal * (1.0 - state.world->GetConfig()->STEAL_PENALTY()));\
-
 
       //New Steal Implementation
-      //emp::Ptr<HealthHost> health_host = host.DynamicCast<HealthHost>();
-      host->CycleTransfer(int(state.world->GetConfig()->CYCLES_PER_UPDATE() * -1));
 
+      host->CycleTransfer(int(state.world->GetConfig()->CYCLES_PER_UPDATE() * -1));
     }
+  }
+  else{
   }
 });
 

--- a/source/sgp_mode/Instructions.h
+++ b/source/sgp_mode/Instructions.h
@@ -1,9 +1,12 @@
 #ifndef INSTRUCTIONS_H
 #define INSTRUCTIONS_H
 
+
 #include "CPUState.h"
 #include "SGPWorld.h"
 #include "Tasks.h"
+
+
 #include "sgpl/hardware/Cpu.hpp"
 #include "sgpl/operations/flow_global/Anchor.hpp"
 #include "sgpl/program/Program.hpp"
@@ -139,17 +142,26 @@ INST(Donate, {
     if (state.organism->IsHost() || state.organism->GetHost() == nullptr)
       return;
     if (emp::Ptr<Organism> host = state.organism->GetHost()) {
+      //Original Donate implementation:
       // Donate 20% of the total points of the symbiont-host system
       // This way, a sym can donate e.g. 40 or 60 percent of their points in a
       // couple of instructions
-      double to_donate =
-          fmin(state.organism->GetPoints(),
-               (state.organism->GetPoints() + host->GetPoints()) * 0.20);
-      state.world->GetSymDonatedDataNode().WithMonitor(
-          [=](auto &m) { m.AddDatum(to_donate); });
-      host->AddPoints(to_donate *
-                      (1.0 - state.world->GetConfig()->DONATE_PENALTY()));
-      state.organism->AddPoints(-to_donate);
+      // double to_donate =
+      //     fmin(state.organism->GetPoints(),
+      //          (state.organism->GetPoints() + host->GetPoints()) * 0.20);
+      // state.world->GetSymDonatedDataNode().WithMonitor(
+      //     [=](auto &m) { m.AddDatum(to_donate); });
+      // host->AddPoints(to_donate *
+      //                 (1.0 - state.world->GetConfig()->DONATE_PENALTY()));
+      // state.organism->AddPoints(-to_donate);
+
+
+
+      //New Donate implementation:
+      //emp::Ptr<HealthHost> health_host = host.DynamicCast<HealthHost>();
+      host->CycleTransfer(int(state.world->GetConfig()->CYCLES_PER_UPDATE()));
+     // std::cout << "Im making good things happen" << std::endl;
+
     }
   }
 });
@@ -158,18 +170,25 @@ INST(Steal, {
     if (state.organism->IsHost() || state.organism->GetHost() == nullptr)
       return;
     if (emp::Ptr<Organism> host = state.organism->GetHost()) {
+      //Original Steal Implementation:
       // Steal 20% of the total points of the symbiont-host system
       // This way, a sym can steal e.g. 40 or 60 percent of the host's points in
       // a couple of instructions
-      double to_steal =
-          fmin(host->GetPoints(),
-               (state.organism->GetPoints() + host->GetPoints()) * 0.20);
-      state.world->GetSymStolenDataNode().WithMonitor(
-          [=](auto &m) { m.AddDatum(to_steal); });
-      host->AddPoints(-to_steal);
-      // 10% of the stolen resources are lost
-      state.organism->AddPoints(
-          to_steal * (1.0 - state.world->GetConfig()->STEAL_PENALTY()));
+      // double to_steal =
+      //     fmin(host->GetPoints(),
+      //          (state.organism->GetPoints() + host->GetPoints()) * 0.20);
+      // state.world->GetSymStolenDataNode().WithMonitor(
+      //     [=](auto &m) { m.AddDatum(to_steal); });
+      // host->AddPoints(-to_steal);
+      // // 10% of the stolen resources are lost
+      // state.organism->AddPoints(
+      //     to_steal * (1.0 - state.world->GetConfig()->STEAL_PENALTY()));\
+
+
+      //New Steal Implementation
+      //emp::Ptr<HealthHost> health_host = host.DynamicCast<HealthHost>();
+      host->CycleTransfer(int(state.world->GetConfig()->CYCLES_PER_UPDATE() * -1));
+
     }
   }
 });

--- a/source/sgp_mode/SGPConfigSetup.h
+++ b/source/sgp_mode/SGPConfigSetup.h
@@ -30,8 +30,8 @@ EMP_EXTEND_CONFIG(SymConfigSGP, SymConfigBase,
   VALUE(MUTUALIST_DEATH_CHANCE, double, 0.125, "What death chance does a mutualist confer?"),
   VALUE(BASE_DEATH_CHANCE, double, 0.25, "What death chance does a host have in the absence of symbionts?"),
   VALUE(CPU_TRANSFER_CHANCE, double, 0.5, "What is the chance for cycles to be stolen/donated?"),
-  VALUE(ONLY_FIRST_TASK_CREDIT, int, 0, "Should symbionts only get credit for their first task")
-
+  VALUE(ONLY_FIRST_TASK_CREDIT, int, 0, "Should symbionts only get credit for their first task"),
+  VALUE(ALLOW_TRANSITION_EVOLUTION, int, 0, "Should symbionts be allowed to evolve from mutalists to parasties and vice versa")
 )
 
 #endif

--- a/source/test/sgp_mode_test/HealthHost.test.cc
+++ b/source/test/sgp_mode_test/HealthHost.test.cc
@@ -1,3 +1,5 @@
+#include "../../sgp_mode/GenomeLibrary.h"
+#include "../../sgp_mode/CPU.h"
 #include "../../sgp_mode/HealthHost.h"
 #include "../../sgp_mode/SGPWorld.h"
 #include "../../sgp_mode/SGPWorldSetup.cc"
@@ -146,3 +148,105 @@ TEST_CASE("Health hosts evolve", "[sgp-integration]") {
     }
   }
 } 
+
+TEST_CASE("When DONATION_STEAL_INST is 1 then Symbiont with 'Steal' instruction properly takes CPU cycles from HealthHost", "[sgp]"){
+ 
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(0);
+  config.ORGANISM_TYPE(HEALTH);
+  config.STRESS_TYPE(PARASITE);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.00);
+  config.TRACK_PARENT_TASKS(1);
+  config.VT_TASK_MATCH(1);
+  config.ONLY_FIRST_TASK_CREDIT(1);
+  config.HOST_REPRO_RES(10000);
+  config.DONATION_STEAL_INST(1);
+
+
+  SGPWorld world(random, &config, LogicTasks);
+
+  //Builds program that does both NOT and NAND operations
+
+
+  //Creates a host that only does NOT operations
+  emp::Ptr<HealthHost> host = emp::NewPtr<HealthHost>(&random, &world, &config, CreateNotProgram(100));
+  //Creates a symbiont that does both Not and Nand operations
+  emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, CreateParasiteNotProgram(100));
+
+  //Adds host to world and sym to host.
+  world.AddOrgAt(host, 0);
+  host->AddSymbiont(sym);
+    
+  WHEN("A symbiont performs a Steal instruction"){
+  sym->GetCPU().RunCPUStep(0, 100);
+  (*(sym->GetCPU().state.tasks_performed))[0] = 0;
+  THEN("The host should be set to lose 4 cycles to the symbiont"){
+    REQUIRE(host->GetCyclesGiven() == -4);
+  }
+  for (size_t i = 0; i < 24; i++) {
+    world.Update();
+    }
+THEN("The symbiont should complete its task one update early"){
+  REQUIRE(sym->GetCPU().state.tasks_performed->Get(0) == true);
+}
+  world.Update();
+  THEN("The host should be unable to complete its task in 25 updates"){
+    REQUIRE(host->GetCPU().state.tasks_performed->Get(0) == false);
+  }
+}
+
+}
+
+TEST_CASE("When DONATION_STEAL_INST is 1 then Symbiont with 'Donate' instruction properly gives CPU cycles to HealthHost", "[sgp]"){
+ 
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(0);
+  config.ORGANISM_TYPE(HEALTH);
+  config.STRESS_TYPE(PARASITE);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.00);
+  config.TRACK_PARENT_TASKS(1);
+  config.VT_TASK_MATCH(1);
+  config.ONLY_FIRST_TASK_CREDIT(1);
+  config.DONATION_STEAL_INST(1);
+
+  config.HOST_REPRO_RES(10000);
+
+  SGPWorld world(random, &config, LogicTasks);
+
+  //Builds program that does both NOT and NAND operations
+
+
+  //Creates a host that only does NOT operations
+  emp::Ptr<HealthHost> host = emp::NewPtr<HealthHost>(&random, &world, &config, CreateNotProgram(100));
+  //Creates a symbiont that does both Not and Nand operations
+  emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, CreateMutualistNotProgram(100));
+
+  //Adds host to world and sym to host.
+  world.AddOrgAt(host, 0);
+  host->AddSymbiont(sym);
+    
+WHEN("A symbiont performs a Donate instruction"){
+  sym->GetCPU().RunCPUStep(0, 100);
+  (*(sym->GetCPU().state.tasks_performed))[0] = 0;
+  THEN("The host should be set to gain 4 cycles from the symbiont"){
+    REQUIRE(host->GetCyclesGiven() == 4);
+  }
+  for (size_t i = 0; i < 24; i++) {
+    world.Update();
+    }
+THEN("The host should complete its task one update early"){
+  REQUIRE(host->GetCPU().state.tasks_performed->Get(0) == true);
+}
+  world.Update();
+  THEN("The symbiont should be unable to complete its task in 25 updates"){
+    REQUIRE(sym->GetCPU().state.tasks_performed->Get(0) == false);
+  }
+
+}
+}

--- a/source/test/sgp_mode_test/SGPHost.test.cc
+++ b/source/test/sgp_mode_test/SGPHost.test.cc
@@ -215,3 +215,231 @@ TEST_CASE("SGPHost Reproduce", "[sgp]") {
     }
   } 
 }
+
+TEST_CASE("When ONLY_FIRST_TASK_CREDIT is 1, the most tasks a Host can receive credit for is 1", "[sgp]"){
+
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(1);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.002);
+  config.TRACK_PARENT_TASKS(1);
+  config.VT_TASK_MATCH(1);
+  config.ONLY_FIRST_TASK_CREDIT(1);
+
+  SGPWorld world(random, &config, LogicTasks);
+
+
+  WHEN("Hosts are able to complete both NOT and NAND tasks"){
+    
+    //Builds program that does both NOT and NAND operations
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+
+    //Creates a host that does both Not and Nand operations
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that does both Not and Nand operations
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Host completes both NOT and NAND tasks"){
+    
+      host->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += host->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Host should only get credit for completing 1 task"){
+        REQUIRE(tasks_completed == 1);
+      }
+    }
+  }
+
+  WHEN("Hosts are able to complete all tasks"){
+    
+    //Builds program that does all tasks
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+    program.AddAnd();
+    program.AddOrn();
+    program.AddOr();
+    program.AddAndn();
+    program.AddNor();
+    program.AddXor();
+    program.AddEqu();
+
+    //Creates a host that can do all tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that can do all tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Host completes all tasks"){
+    
+      host->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += host->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Host should only get credit for completing 1 task"){
+        REQUIRE(tasks_completed == 1);
+      }
+    }
+  }
+
+  WHEN("Hosts are unable to complete any tasks"){
+    
+    //Empty Builder
+    ProgramBuilder program;
+    //Creates a host that cannot do any tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that cannot do any tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+    WHEN("Host completes no tasks"){
+    
+      host->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += host->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Host should not get credit for any tasks"){
+        REQUIRE(tasks_completed == 0);
+      }
+    }
+  }
+  
+
+}
+
+TEST_CASE("When ONLY_FIRST_TASK_CREDIT is 0, hosts receive credit for all tasks they complete", "[sgp]"){
+
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(2);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.002);
+  config.TRACK_PARENT_TASKS(1);
+  config.VT_TASK_MATCH(1);
+  config.ONLY_FIRST_TASK_CREDIT(0);
+
+  SGPWorld world(random, &config, LogicTasks);
+
+
+  WHEN("Host are able to complete both NOT and NAND tasks"){
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+
+    //Creates a host that only does NOT operations
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that does both Not and Nand operations
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+    WHEN("Host completes both NOT and NAND tasks"){
+    
+      host->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += host->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Host should recieve credit for completing 2 tasks"){
+        REQUIRE(tasks_completed == 2);
+      }
+    }
+  }
+
+  WHEN("Hosts are able to complete all tasks"){
+
+    //Builds program that completes all tasks
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+    program.AddAnd();
+    program.AddOrn();
+    program.AddOr();
+    program.AddAndn();
+    program.AddNor();
+    program.AddXor();
+    program.AddEqu();
+    //Creates a host that can do all tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that can do all tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+    WHEN("Host completes all tasks"){
+    
+      host->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += host->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Host should get credit for completing all 9 tasks"){
+        REQUIRE(tasks_completed == 9);
+      }
+    }
+  }
+
+  WHEN("Host are unable to complete any tasks"){
+    //Empty Builder
+    ProgramBuilder program;
+    //Creates a host that cannot do any tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that cannot do any tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+    WHEN("Host completes no tasks"){
+    
+      host->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += host->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Host should not get credit for any tasks"){
+        REQUIRE(tasks_completed == 0);
+      }
+    }
+  }
+  
+
+}

--- a/source/test/sgp_mode_test/SGPSymbiont.test.cc
+++ b/source/test/sgp_mode_test/SGPSymbiont.test.cc
@@ -63,3 +63,247 @@ TEST_CASE("SGPSymbiont Reproduce", "[sgp]") {
     sym_baby.Delete();
   }
 }
+
+
+TEST_CASE("When ONLY_FIRST_TASK_CREDIT is 1, the most tasks a symbiont can receive credit for is 1", "[sgp]"){
+
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(1);
+  config.ORGANISM_TYPE(HEALTH);
+  config.STRESS_TYPE(PARASITE);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.002);
+  config.TRACK_PARENT_TASKS(1);
+  config.VT_TASK_MATCH(1);
+  config.ONLY_FIRST_TASK_CREDIT(1);
+
+  SGPWorld world(random, &config, LogicTasks);
+
+
+  WHEN("Symbionts are able to complete both NOT and NAND tasks"){
+    
+    //Builds program that does both NOT and NAND operations
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+
+    //Creates a host that does both Not and Nand operations
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that does both Not and Nand operations
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Symbiont completes both NOT and NAND tasks"){
+    
+      sym->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += sym->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Symbiont should only get credit for completing 1 task"){
+        REQUIRE(tasks_completed == 1);
+      }
+    }
+
+
+  }
+
+  WHEN("Symbionts are able to complete all tasks"){
+    
+    //Builds program that does all tasks
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+    program.AddAnd();
+    program.AddOrn();
+    program.AddOr();
+    program.AddAndn();
+    program.AddNor();
+    program.AddXor();
+    program.AddEqu();
+
+    //Creates a host that can do all tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that can do all tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Symbiont completes all tasks"){
+    
+      sym->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += sym->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Symbiont should only get credit for completing 1 task"){
+        REQUIRE(tasks_completed == 1);
+      }
+    }
+
+  }
+
+  WHEN("Symbionts are unable to complete any tasks"){
+    
+    //Empty Builder
+    ProgramBuilder program;
+    //Creates a host that cannot do any tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that cannot do any tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Symbiont completes no tasks"){
+    
+      sym->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += sym->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Symbiont should not get credit for any tasks"){
+        REQUIRE(tasks_completed == 0);
+      }
+    }
+
+  }
+  
+
+}
+
+TEST_CASE("When ONLY_FIRST_TASK_CREDIT is 0, symbionts receive credit for all tasks they complete", "[sgp]"){
+
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(2);
+  config.ORGANISM_TYPE(HEALTH);
+  config.STRESS_TYPE(PARASITE);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.002);
+  config.TRACK_PARENT_TASKS(1);
+  config.VT_TASK_MATCH(1);
+  config.ONLY_FIRST_TASK_CREDIT(0);
+
+  SGPWorld world(random, &config, LogicTasks);
+
+
+  WHEN("Symbionts are able to complete both NOT and NAND tasks"){
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+
+    //Creates a host that only does NOT operations
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that does both Not and Nand operations
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Symbiont completes both NOT and NAND tasks"){
+    
+      sym->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += sym->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Symbiont should recieve credit for completing 2 tasks"){
+        REQUIRE(tasks_completed == 2);
+      }
+    }
+
+  }
+
+  WHEN("Symbionts are able to complete all tasks"){
+
+    //Builds program that completes all tasks
+    ProgramBuilder program;
+    program.AddNot();
+    program.AddNand();
+    program.AddAnd();
+    program.AddOrn();
+    program.AddOr();
+    program.AddAndn();
+    program.AddNor();
+    program.AddXor();
+    program.AddEqu();
+    //Creates a host that can do all tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that can do all tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Symbiont completes all tasks"){
+    
+      sym->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += sym->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Symbiont should get credit for completing all 9 tasks"){
+        REQUIRE(tasks_completed == 9);
+      }
+    }
+
+  }
+
+  WHEN("Symbionts are unable to complete any tasks"){
+    //Empty Builder
+    ProgramBuilder program;
+    //Creates a host that cannot do any tasks
+    emp::Ptr<SGPHost> host = emp::NewPtr<SGPHost>(&random, &world, &config, program.Build(100));
+    
+    //Creates a symbiont that cannot do any tasks
+    emp::Ptr<SGPSymbiont> sym = emp::NewPtr<SGPSymbiont>(&random, &world, &config, program.Build(100));
+
+    //Adds host to world and sym to host.
+    world.AddOrgAt(host, 0);
+    host->AddSymbiont(sym);
+
+
+    WHEN("Symbiont completes no tasks"){
+    
+      sym->GetCPU().RunCPUStep(0, 100);
+      
+      int tasks_completed = 0;
+      for (int i = 0; i < CPU_BITSET_LENGTH; i++) {
+        tasks_completed += sym->GetCPU().state.tasks_performed->Get(i);
+      }
+      THEN("Symbiont should not get credit for any tasks"){
+        REQUIRE(tasks_completed == 0);
+      }
+    }
+
+  }
+  
+
+}

--- a/source/test/sgp_mode_test/SGPWorld.test.cc
+++ b/source/test/sgp_mode_test/SGPWorld.test.cc
@@ -138,6 +138,63 @@ TEST_CASE("TaskMatchCheck", "[sgp]") {
 
 }
 
+TEST_CASE("Organisms, without mutation will only recieve credit for NOT operations", "[sgp]") {
+     
+  emp::Random random(1);
+  SymConfigSGP config;
+  config.RANDOM_ANCESTOR(false);
+  config.SEED(2);
+  config.ORGANISM_TYPE(HEALTH);
+  config.STRESS_TYPE(PARASITE);
+  config.MUTATION_RATE(0.0);
+  config.MUTATION_SIZE(0.000);
+  SGPWorld world(random, &config, LogicTasks);
+
+  // Mock Organism to check reproduction
+  class TestOrg : public Organism {
+  public:
+    bool IsHost() override { return true; }
+    void AddPoints(double p) override {}
+    double GetPoints() override { return 0; }
+  };
+
+  TestOrg organism;
+
+  // NOT builder
+  ProgramBuilder builder;
+  (builder.AddNot)();
+  CPU cpu(&organism, &world, builder.Build(100));
+  
+  
+  
+  cpu.RunCPUStep(0, 100);
+  
+  //The result of a AND bitwise operations when one of the inputs, in binary, is all ones will be the other input
+  int all_ones_binary = 4294967295;
+  cpu.state.input_buf.push(all_ones_binary);
+  cpu.RunCPUStep(0, 100);
+  world.Update();
+
+  //Checks both that NOT is being done and no other operations are being done
+  for (auto data : world.GetTaskSet()) {
+    
+      if(data.task.name != "NOT"){
+    
+       REQUIRE(data.n_succeeds_host == 0);
+      }
+      else{
+        REQUIRE(data.n_succeeds_host > 0);
+      }
+    
+  }
+
+  cpu.state.shared_available_dependencies.Delete();
+  cpu.state.used_resources.Delete();
+  cpu.state.internal_environment.Delete();
+
+
+}
+
 TEST_CASE("Ousting is permitted", "[sgp]") {
   emp::Random random(61);
   SymConfigSGP config;


### PR DESCRIPTION
This allows symbionts of a Health host to gain "donate" and "steal" instructions. Currently, both donate and steal are both available, in order to turn off one of these, comment it out in the library section of GenomeLibrary.h. 